### PR TITLE
feat(record-type): add `purpose` table 

### DIFF
--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1,4 +1,3 @@
-from enum import Enum
 import uuid
 
 from contextlib import contextmanager
@@ -13,7 +12,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
@@ -53,7 +51,8 @@ class IndexRecord(Base):
 
 class IndexRecordUrlPurpose(Base):
     """
-    TODO
+    A field to describe the purpose of the data stored an an
+    ``IndexRecordUrl``.
     """
     __tablename__ = 'index_record_url_purpose'
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         'flask==0.10.1',
         'jsonschema==2.5.1',
-        'sqlalchemy==1.0.8',
+        'sqlalchemy==0.9.9',
     	'psycopg2==2.6.1',
         'cdispyutils',
     ],

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -26,6 +26,10 @@ INDEX_TABLES = {
     'index_record_url': [
         (0, u'did', u'VARCHAR', 1, None, 1),
         (1, u'url', u'VARCHAR', 1, None, 1 if OLD_SQLITE else 2),
+        (2, u'purpose', u'VARCHAR', 0, None, 0),
+    ],
+    'index_record_url_purpose': [
+        (0, u'purpose', u'VARCHAR', 1, None, 1),
     ],
 }
 


### PR DESCRIPTION
Resolves #41.

Adds the `IndexRecordUrlPurpose` table, containing a single column `purpose` which defines an enumeration of possible types/purposes for the data.