### PR TITLE
feat(schema_version): track schema and migrate

### DIFF
--- a/bin/index_admin.py
+++ b/bin/index_admin.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import sys
 
@@ -7,24 +8,32 @@ def main(path, action=None, username=None, password=None):
     try:
         from local_settings import settings
     except ImportError:
-        print "Can't import local_settings, import from default"
+        print("Can't import local_settings, import from default")
         from indexd.default_settings import settings
     driver = settings['auth']
+    index_driver = settings['config']['INDEX']['driver']
+    alias_driver = settings['config']['ALIAS']['driver']
     if action == 'create':
         try:
             driver.add(username, password)
-            print 'User {} created'.format(username)
+            print('User {} created'.format(username))
         except Exception as e:
-            print e.message
+            print(e.message)
 
     elif action == 'delete':
         try:
             driver.delete(username)
-            print 'User {} deleted'.format(username)
+            print('User {} deleted'.format(username))
         except Exception as e:
-            print e.message
+            print(e.message)
 
-
+    elif action == 'migrate_database':
+        try:
+            print('Start database migration')
+            alias_driver.migrate_database()
+            index_driver.migrate_database()
+        except Exception as e:
+            print(e.message)
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
@@ -37,9 +46,9 @@ if __name__ == '__main__':
     subparsers = parser.add_subparsers(title='action', dest='action')
     create = subparsers.add_parser('create')
     delete = subparsers.add_parser('delete')
+    migrate = subparsers.add_parser('migrate_database')
     create.add_argument('--username', required=True)
     create.add_argument('--password', required=True)
     delete.add_argument('--username', required=True)
     args = parser.parse_args()
-
     main(**args.__dict__)

--- a/bin/index_admin.py
+++ b/bin/index_admin.py
@@ -1,14 +1,15 @@
-from __future__ import print_function
 import argparse
 import sys
+from cdispyutils.log import get_logger
 
+logger = get_logger('index_admin')
 
 def main(path, action=None, username=None, password=None):
     sys.path.append(path)
     try:
         from local_settings import settings
     except ImportError:
-        print("Can't import local_settings, import from default")
+        logger.info("Can't import local_settings, import from default")
         from indexd.default_settings import settings
     driver = settings['auth']
     index_driver = settings['config']['INDEX']['driver']
@@ -16,24 +17,24 @@ def main(path, action=None, username=None, password=None):
     if action == 'create':
         try:
             driver.add(username, password)
-            print('User {} created'.format(username))
+            logger.info('User {} created'.format(username))
         except Exception as e:
-            print(e.message)
+            logger.error(e.message)
 
     elif action == 'delete':
         try:
             driver.delete(username)
-            print('User {} deleted'.format(username))
+            logger.info('User {} deleted'.format(username))
         except Exception as e:
-            print(e.message)
+            logger.error(e.message)
 
     elif action == 'migrate_database':
         try:
-            print('Start database migration')
+            logger.info('Start database migration')
             alias_driver.migrate_database()
             index_driver.migrate_database()
         except Exception as e:
-            print(e.message)
+            logger.error(e.message)
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()

--- a/indexd/alias/drivers/alchemy.py
+++ b/indexd/alias/drivers/alchemy.py
@@ -27,10 +27,8 @@ from indexd.utils import migrate_database
 
 Base = declarative_base()
 
-CURRENT_SCHEMA_VERSION = 0
-# ordered schema migration functions that the index should correspond to
-#  CURRENT_SCHEMA_VERSION - 1 when it's written
-SCHEMA_MIGRATION_FUNCTIONS = []
+CURRENT_SCHEMA_VERSION = 1
+
 
 class AliasSchemaVersion(Base):
     '''
@@ -287,3 +285,14 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
         '''
         with self.session as session:
             return session.query(AliasRecord).count()
+
+
+def migrate_1(session, **kwargs):
+    session.execute(
+        "ALTER TABLE {} ALTER COLUMN size TYPE bigint;"
+        .format(AliasRecord.__tablename__))
+
+
+# ordered schema migration functions that the index should correspond to
+# CURRENT_SCHEMA_VERSION - 1 when it's written
+SCHEMA_MIGRATION_FUNCTIONS = [migrate_1]

--- a/indexd/alias/drivers/alchemy.py
+++ b/indexd/alias/drivers/alchemy.py
@@ -8,6 +8,7 @@ from sqlalchemy import and_
 from sqlalchemy import String
 from sqlalchemy import Column
 from sqlalchemy import Integer
+from sqlalchemy import BigInteger
 from sqlalchemy import ForeignKey
 from sqlalchemy import create_engine
 from sqlalchemy.orm import relationship
@@ -45,7 +46,7 @@ class AliasRecord(Base):
 
     name = Column(String, primary_key=True)
     rev = Column(String)
-    size = Column(Integer)
+    size = Column(BigInteger)
 
     hashes = relationship('AliasRecordHash',
         backref='alias_record',

--- a/indexd/default_settings.py
+++ b/indexd/default_settings.py
@@ -5,12 +5,16 @@ from .auth.drivers.alchemy import SQLAlchemyAuthDriver
 CONFIG = {}
 
 CONFIG['JSONIFY_PRETTYPRINT_REGULAR'] = False
+AUTO_MIGRATE = True
+
 CONFIG['INDEX'] = {
-    'driver':  SQLAlchemyIndexDriver('sqlite:///index.sq3'),
+    'driver':  SQLAlchemyIndexDriver(
+        'sqlite:///index.sq3', auto_migrate=AUTO_MIGRATE),
 }
 
 CONFIG['ALIAS'] = {
-    'driver': SQLAlchemyAliasDriver('sqlite:///alias.sq3'),
+    'driver': SQLAlchemyAliasDriver(
+        'sqlite:///alias.sq3', auto_migrate=AUTO_MIGRATE),
 }
 
 AUTH = SQLAlchemyAuthDriver('sqlite:///auth.sq3')

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -31,10 +31,7 @@ from indexd.utils import migrate_database
 Base = declarative_base()
 
 
-CURRENT_SCHEMA_VERSION = 0
-# ordered schema migration functions that the index should correspond to
-# CURRENT_SCHEMA_VERSION - 1 when it's written
-SCHEMA_MIGRATION_FUNCTIONS = []
+CURRENT_SCHEMA_VERSION = 1
 
 
 class IndexSchemaVersion(Base):
@@ -374,5 +371,16 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         Number of unique records stored by backend.
         '''
         with self.session as session:
-            
+
             return session.execute(select([func.count()]).select_from(IndexRecord)).scalar()
+
+
+def migrate_1(session, **kwargs):
+    session.execute(
+        "ALTER TABLE {} ALTER COLUMN size TYPE bigint;"
+        .format(IndexRecord.__tablename__))
+
+
+# ordered schema migration functions that the index should correspond to
+# CURRENT_SCHEMA_VERSION - 1 when it's written
+SCHEMA_MIGRATION_FUNCTIONS = [migrate_1]

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -9,6 +9,7 @@ from sqlalchemy import and_
 from sqlalchemy import String
 from sqlalchemy import Column
 from sqlalchemy import Integer
+from sqlalchemy import BigInteger
 from sqlalchemy import ForeignKey
 from sqlalchemy import create_engine
 from sqlalchemy.orm import relationship
@@ -51,7 +52,7 @@ class IndexRecord(Base):
     did = Column(String, primary_key=True)
     rev = Column(String)
     form = Column(String)
-    size = Column(Integer)
+    size = Column(BigInteger)
 
     urls = relationship(
         'IndexRecordUrl',
@@ -364,7 +365,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             result = session.execute(select([func.sum(IndexRecord.size)])).scalar()
             if result is None:
                 return 0
-            return result
+            return long(result)
 
     def len(self):
         '''

--- a/indexd/utils.py
+++ b/indexd/utils.py
@@ -1,0 +1,65 @@
+def check_engine_for_migrate(engine):
+    '''
+    check if a db engine support database migration
+
+    Args:
+        engine (sqlalchemy.engine.base.Engine): a sqlalchemy engine
+
+    Return:
+        bool: whether the engine support migration
+    '''
+    return engine.dialect.supports_alter
+
+
+def init_schema_version(driver, model):
+    '''
+    initialize schema table with a singleton of version 0
+
+    Args:
+        driver (object): an alias or index driver instance
+        model (sqlalchemy.ext.declarative.api.Base): the version table model
+
+    Return:
+        version (int): current version number in database
+    '''
+    with driver.session as s:
+        schema_version = s.query(model).first()
+        if not schema_version:
+            schema_version = model(version=0)
+            s.add(schema_version)
+        version = schema_version.version
+    return version
+
+
+def migrate_database(driver, migrate_functions, current_schema_version, model):
+    '''
+    migrate current database to match the schema version provded in
+    current schema
+
+    Args:
+        driver (object): an alias or index driver instance
+        migrate_functions (list): a list of migration functions
+        curent_schema_version (int): version of current schema in code
+        model (sqlalchemy.ext.declarative.api.Base): the version table model
+
+    Return:
+        None
+    '''
+    db_schema_version = init_schema_version(driver, model)
+    need_migrate = (current_schema_version - db_schema_version) > 0
+
+    if not check_engine_for_migrate(driver.engine) and need_migrate:
+        driver.logger.error(
+            'This engine does not support alter, skip migration')
+        return
+    for f in migrate_functions[
+            db_schema_version:current_schema_version]:
+        with driver.session as s:
+            schema_version = s.query(model).first()
+            schema_version.version += 1
+            driver.logger.info('migrating {} schema to {}'.format(
+                driver.__class__.__name__,
+                schema_version.version))
+
+            f(engine=driver.engine, session=s)
+            s.add(schema_version)

--- a/indexd/utils.py
+++ b/indexd/utils.py
@@ -50,7 +50,8 @@ def migrate_database(driver, migrate_functions, current_schema_version, model):
 
     if not check_engine_for_migrate(driver.engine) and need_migrate:
         driver.logger.error(
-            'This engine does not support alter, skip migration')
+            'Engine {} does not support alter, skip migration'.format(
+                driver.engine.dialect.name))
         return
     for f in migrate_functions[
             db_schema_version:current_schema_version]:

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1,0 +1,91 @@
+from indexd.index.drivers.alchemy import (
+    SQLAlchemyIndexDriver, IndexSchemaVersion)
+
+from indexd.alias.drivers.alchemy import (
+    SQLAlchemyAliasDriver, AliasSchemaVersion)
+
+
+def test_migrate_index(monkeypatch):
+    called = []
+
+    def mock_migrate(**kwargs):
+        called.append(True)
+
+    monkeypatch.setattr(
+        'indexd.index.drivers.alchemy.CURRENT_SCHEMA_VERSION', 2)
+    monkeypatch.setattr(
+         'indexd.utils.check_engine_for_migrate',
+         lambda _: True
+    )
+    monkeypatch.setattr(
+        'indexd.index.drivers.alchemy.SCHEMA_MIGRATION_FUNCTIONS',
+        [mock_migrate, mock_migrate])
+
+    driver = SQLAlchemyIndexDriver('sqlite:///index.sq3')
+    assert len(called) == 2
+    with driver.session as s:
+        v = s.query(IndexSchemaVersion).first()
+        assert v.version == 2
+        s.delete(v)
+
+def test_migrate_index_only_diff(monkeypatch):
+    called = []
+
+    def mock_migrate(**kwargs):
+        called.append(True)
+
+    called_2 = []
+    def mock_migrate_2(**kwargs):
+        called_2.append(True)
+
+    monkeypatch.setattr(
+         'indexd.utils.check_engine_for_migrate',
+         lambda _: True
+    )
+    monkeypatch.setattr(
+        'indexd.index.drivers.alchemy.CURRENT_SCHEMA_VERSION', 1)
+    monkeypatch.setattr(
+        'indexd.index.drivers.alchemy.SCHEMA_MIGRATION_FUNCTIONS',
+        [mock_migrate, mock_migrate_2])
+
+    driver = SQLAlchemyIndexDriver('sqlite:///index.sq3')
+    assert len(called) == 1
+    assert len(called_2) == 0
+
+    called = []
+    called_2 = []
+    monkeypatch.setattr(
+        'indexd.index.drivers.alchemy.CURRENT_SCHEMA_VERSION', 2)
+
+    driver = SQLAlchemyIndexDriver('sqlite:///index.sq3')
+    assert len(called) == 0
+    assert len(called_2) == 1
+
+    with driver.session as s:
+        v = s.query(IndexSchemaVersion).first()
+        assert v.version == 2
+        s.delete(v)
+
+def test_migrate_alias(monkeypatch):
+    called = []
+
+    def mock_migrate(**kwargs):
+        called.append(True)
+
+    monkeypatch.setattr(
+        'indexd.alias.drivers.alchemy.CURRENT_SCHEMA_VERSION', 1)
+    monkeypatch.setattr(
+        'indexd.alias.drivers.alchemy.SCHEMA_MIGRATION_FUNCTIONS',
+        [mock_migrate])
+
+    monkeypatch.setattr(
+         'indexd.utils.check_engine_for_migrate',
+         lambda _: True
+    )
+
+    driver = SQLAlchemyAliasDriver('sqlite:///alias.sq3')
+    assert len(called) == 1
+    with driver.session as s:
+        v = s.query(AliasSchemaVersion).first()
+        assert v.version == 1
+        s.delete(v)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -16,7 +16,7 @@ INDEX_TABLES = {
         (0, u'did', u'VARCHAR', 1, None, 1),
         (1, u'rev', u'VARCHAR', 0, None, 0),
         (2, u'form', u'VARCHAR', 0, None, 0),
-        (3, u'size', u'INTEGER', 0, None, 0),
+        (3, u'size', u'BIGINT', 0, None, 0),
     ],
     'index_record_hash': [
         (0, u'did', u'VARCHAR', 1, None, 1),
@@ -33,7 +33,7 @@ ALIAS_TABLES = {
     'alias_record': [
         (0, u'name', u'VARCHAR', 1, None, 1),
         (1, u'rev', u'VARCHAR', 0, None, 0),
-        (2, u'size', u'INTEGER', 0, None, 0),
+        (2, u'size', u'BIGINT', 0, None, 0),
         (3, u'release', u'VARCHAR', 0, None, 0),
         (4, u'metastring', u'VARCHAR', 0, None, 0),
         (5, u'keeper_authority', u'VARCHAR', 0, None, 0),


### PR DESCRIPTION
- still keep alias and index separate as is
- initialize any db with version 0
- auto migrate to latest version based on version diff

when we need a version upgrade, the pr will bump the version in `SQLAlchemyIndexDriver.current_version`, and create a migration function appended to [all_migration_functions](https://github.com/uc-cdis/indexd/compare/feat/schema_version?expand=1#diff-395f548de47be5f9dbaf677448d33ff1R102)
