### PR TITLE
fix(migration): fix migration scripts

### DIFF
--- a/indexd/alias/drivers/alchemy.py
+++ b/indexd/alias/drivers/alchemy.py
@@ -97,8 +97,9 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
         Base.metadata.bind = self.engine
         self.Session = sessionmaker(bind=self.engine)
 
-        if is_empty_database(driver=self):
-            Base.metadata.create_all()
+        is_empty_db = is_empty_database(driver=self)
+        Base.metadata.create_all()
+        if is_empty_db:
             init_schema_version(driver=self, model=AliasSchemaVersion, version=CURRENT_SCHEMA_VERSION)
 
         if auto_migrate:


### PR DESCRIPTION
Fix couple of issues:
- make create_all() for both old empty and old non-empty DB
- in case of brand-new db, don't need run migrate scripts