### PR TITLE
fix(update_doc): allow setting version to None 

### DIFF
--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -262,31 +262,19 @@ def post_index_record():
 @blueprint.route('/index/<path:record>', methods=['PUT'])
 @authorize
 def put_index_record(record):
-    '''
+    """
     Update an existing record.
-    '''
+    """
     try:
         jsonschema.validate(flask.request.json, PUT_RECORD_SCHEMA)
     except jsonschema.ValidationError as err:
         raise UserError(err)
-
     rev = flask.request.args.get('rev')
-    file_name = flask.request.json.get('file_name')
-    version = flask.request.json.get('version')
-    urls = flask.request.json.get('urls')
-    acl = flask.request.json.get('acl')
-    metadata = flask.request.json.get('metadata')
-    urls_metadata = flask.request.json.get('urls_metadata')
 
     did, baseid, rev = blueprint.index_driver.update(
         record,
         rev,
-        file_name=file_name,
-        version=version,
-        urls=urls,
-        acl=acl,
-        metadata=metadata,
-        urls_metadata=urls_metadata,
+        flask.request.json,
     )
 
     ret = {

--- a/indexd/index/driver.py
+++ b/indexd/index/driver.py
@@ -54,9 +54,7 @@ class IndexDriverABC(SQLAlchemyDriverBase):
         raise NotImplementedError('TODO')
 
     @abc.abstractmethod
-    def update(self,
-               did, rev, urls=None, file_name=None,
-               urls_metadata=None, version=None, metadata=None):
+    def update(self, did, rev, changing_fields):
         '''
         Updates record with new values.
         '''

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -698,8 +698,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             if file_name is not None:
                 record.file_name = file_name
 
-            if version is not None:
-                record.version = version
+            record.version = version
 
             record.rev = str(uuid.uuid4())[:8]
 

--- a/indexd/index/schema.py
+++ b/indexd/index/schema.py
@@ -144,7 +144,7 @@ PUT_RECORD_SCHEMA = {
         "type": "string"
     },
     "version": {
-        "type": "string"
+        "type": ["string", "null"]
     },
     "metadata": {
         "type": "object"
@@ -152,9 +152,5 @@ PUT_RECORD_SCHEMA = {
     "urls_metadata": {
         "type": "object"
     },
-    "rev": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{8}$",
-     },
   }
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -649,3 +649,36 @@ def test_dos_list(swg_index_client, swg_dos_client):
     assert r.data_objects[0].urls[0].url == "s3://endpointurl/bucket/key"
     assert r.data_objects[0].urls[0].user_metadata['state'] == "uploaded"
     assert r.data_objects[0].urls[0].system_metadata['project_id'] == "bpa-UChicago"
+
+
+def test_update_without_changing_fields(swg_index_client):
+    # setup test
+    data = get_doc(has_urls_metadata=True, has_metadata=True, has_baseid=True)
+
+    result = swg_index_client.add_entry(data)
+    first_doc = swg_index_client.get_entry(result.did)
+
+    # update
+    updated = {'version': 'at least 2'}
+    swg_index_client.update_entry(first_doc.did, rev=first_doc.rev, body=updated)
+
+    # Check if update successful.
+    second_doc = swg_index_client.get_entry(first_doc.did)
+    # Only `version` changed.
+    assert first_doc.version != second_doc.version
+
+    # The rest is the same.
+    assert first_doc.urls == second_doc.urls
+    assert first_doc.size == second_doc.size
+    assert first_doc.file_name == second_doc.file_name
+    assert first_doc.metadata == second_doc.metadata
+
+    # Change `version` to null.
+    # update
+    updated = {'version': None}
+    swg_index_client.update_entry(second_doc.did, rev=second_doc.rev, body=updated)
+
+    # check if update successful
+    third_doc = swg_index_client.get_entry(result.did)
+    # Only `version` changed.
+    assert second_doc.version != third_doc.version

--- a/tests/test_driver_alchemy_crud.py
+++ b/tests/test_driver_alchemy_crud.py
@@ -558,12 +558,13 @@ def test_driver_update_record():
         file_name = 'test'
         version = 'ver_123'
 
-        driver.update(
-            did, rev,
-            urls=update_urls,
-            file_name=file_name,
-            version=version
-        )
+        changing_fields = {
+            'urls': update_urls,
+            'file_name': file_name,
+            'version': version,
+        }
+
+        driver.update(did, rev, changing_fields)
 
         new_did, new_rev, new_file_name, new_version = conn.execute('''
             SELECT did, rev, file_name, version FROM index_record


### PR DESCRIPTION
```
if version is not None:
    record.version = version
```

This behavior blocks being able to nullify the version field. This PR gets rid of this by simply setting it to whatever is coming from the request. Looking at 
https://github.com/uc-cdis/indexd/blob/415f7338845f3e3aa6398d368d85157caab97b50/indexd/index/blueprint.py#L275
there is a possibility that this field is intentionally not set (which resolves to None either way), hence removing the check above leads to unintended results. Which led me to a second solution which uses a sentinel (eg -1, @, ^ etc); which will imply that the user needs to know this special symbol not to use in their versioning scheme. I skipped this solution cos of that.

The implemented solution is in line with using the IndexClient, since to do an update you will need first do a get document, which will mean the right version would be on the document, unless set to something else before calling the patch