### PR TITLE
fix(bulk-eager): use joinedload for query in bulk API.

### DIFF
--- a/indexd/bulk/blueprint.py
+++ b/indexd/bulk/blueprint.py
@@ -27,12 +27,15 @@ def bulk_get_documents():
         raise UserError('ids is not a list')
 
     with blueprint.index_driver.session as session:
-        """"query = session.query(IndexRecord)
-        query = query.filter(IndexRecord.did.in_(ids))"""
+        
+        # Comment it out to compare against the eager loading option.
+        #query = session.query(IndexRecord)
+        #query = query.filter(IndexRecord.did.in_(ids)
 
-        """use eager loading """
+        # Use eager loading.
         query = session.query(IndexRecord)
-        query = query.options(joinedload(IndexRecord.urls).joinedload(IndexRecordUrl.url_metadata))
+        query = query.options(joinedload(IndexRecord.urls).
+                              joinedload(IndexRecordUrl.url_metadata))
         query = query.options(joinedload(IndexRecord.acl))
         query = query.options(joinedload(IndexRecord.hashes))
         query = query.options(joinedload(IndexRecord.index_metadata))

--- a/indexd/bulk/blueprint.py
+++ b/indexd/bulk/blueprint.py
@@ -4,7 +4,10 @@ import json
 import flask
 
 from indexd.errors import UserError
-from indexd.index.drivers.alchemy import IndexRecord
+from indexd.index.drivers.alchemy import IndexRecord, IndexRecordUrl
+from sqlalchemy.orm import joinedload
+
+
 
 blueprint = flask.Blueprint('bulk', __name__)
 
@@ -24,7 +27,16 @@ def bulk_get_documents():
         raise UserError('ids is not a list')
 
     with blueprint.index_driver.session as session:
+        """"query = session.query(IndexRecord)
+        query = query.filter(IndexRecord.did.in_(ids))"""
+
+        """use eager loading """
         query = session.query(IndexRecord)
+        query = query.options(joinedload(IndexRecord.urls).joinedload(IndexRecordUrl.url_metadata))
+        query = query.options(joinedload(IndexRecord.acl))
+        query = query.options(joinedload(IndexRecord.hashes))
+        query = query.options(joinedload(IndexRecord.index_metadata))
+        query = query.options(joinedload(IndexRecord.aliases))
         query = query.filter(IndexRecord.did.in_(ids))
 
     docs = [q.to_document_dict() for q in query]

--- a/indexd/bulk/blueprint.py
+++ b/indexd/bulk/blueprint.py
@@ -27,7 +27,6 @@ def bulk_get_documents():
         raise UserError('ids is not a list')
 
     with blueprint.index_driver.session as session:
-        
         # Comment it out to compare against the eager loading option.
         #query = session.query(IndexRecord)
         #query = query.filter(IndexRecord.did.in_(ids)

--- a/indexd/default_settings.py
+++ b/indexd/default_settings.py
@@ -9,7 +9,7 @@ AUTO_MIGRATE = True
 
 CONFIG['INDEX'] = {
     'driver':  SQLAlchemyIndexDriver(
-        'sqlite:///index.sq3', auto_migrate=AUTO_MIGRATE,
+        'sqlite:///index.sq3', auto_migrate=AUTO_MIGRATE, echo=True,
         index_config={
             'DEFAULT_PREFIX': 'testprefix:', 'ADD_PREFIX_ALIAS': True,
             'PREPEND_PREFIX': True}
@@ -18,7 +18,7 @@ CONFIG['INDEX'] = {
 
 CONFIG['ALIAS'] = {
     'driver': SQLAlchemyAliasDriver(
-        'sqlite:///alias.sq3', auto_migrate=AUTO_MIGRATE),
+        'sqlite:///alias.sq3', auto_migrate=AUTO_MIGRATE, echo=True),
 }
 
 CONFIG['DIST'] = [


### PR DESCRIPTION
 Temporarily enabled SQLAlchemy logging in default_settings.py to log the actual SQL queries.