### PR TITLE
PXD-2213 Feat/empty record

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ Using AWS SNS or Google PubSub it is possible to have streaming notifications wh
 
 For existing data in buckets, the SNS or PubSub notifications may be simulated such that the indexing functions are started for each object in the bucket. This is useful because only a single code path is necessary for indexing the contents of an object.
 
-3. Using the Indexd REST API for record insertion.
+3. Indexing void object for fully control the bucket structure.
+
+Indexd supports void or blank records that allows users to pre-register data files in indexd before actually registering them. The complete flow contains three main steps: pre-register, hash/size/url populating and data node registration:
+    - Fence requests blank object from indexd. Indexd creates an object with no hash, size, and urls except the `uploader` field.
+    - Indexd listener mornitors bucket update, update to indexd with url, hash, size.
+    - Windmill lists indexd records that’s owned by the user that has empty `acl`. The user fills all empty fields and submit the request to indexd to update the `acl`.
+
+4. Using the Indexd REST API for record insertion.
 
 In rare cases, it may be necessary to interact directly with the Indexd API in order to create index records. This would be necessary if users are loading data into a data commons in non-standard ways or not utilizing Sheepdog as part of their data commons. 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ For existing data in buckets, the SNS or PubSub notifications may be simulated s
 Indexd supports void or blank records that allows users to pre-register data files in indexd before actually registering them. The complete flow contains three main steps: pre-register, hash/size/url populating and data node registration:
     - Fence requests blank object from indexd. Indexd creates an object with no hash, size, and urls except the `uploader` field.
     - Indexd listener mornitors bucket update, update to indexd with url, hash, size.
-    - Windmill lists indexd records that’s owned by the user that has empty `acl`. The user fills all empty fields and submit the request to indexd to update the `acl`.
+    - The client application (windmill or gen3-data-client) lists records for data files which the user needs to submit to the graph. The user fills all empty fields and submit the request to indexd to update the `acl`.
+
+See docs on data upload flow for further details:
+https://github.com/uc-cdis/cdis-wiki/tree/master/dev/gen3/data_upload
 
 4. Using the Indexd REST API for record insertion.
 

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -95,7 +95,8 @@ def get_index():
     metadata = {k: v for k, v in map(lambda x: x.split(':', 1), metadata)}
 
     acl = flask.request.args.get('acl')
-    acl = [] if acl == '' else acl.split(',')
+    if acl:
+        acl = [] if acl == '' else acl.split(',')
 
     urls_metadata = flask.request.args.get('urls_metadata')
     if urls_metadata:

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -273,14 +273,16 @@ def post_index_empty_record():
     '''
 
     uploader = flask.request.json.get('uploader')
+    if not uploader:
+        raise UserError('no uploader specified')
+
     baseid = flask.request.json.get('baseid')
     did = flask.request.json.get('did')
 
     did, rev, baseid = blueprint.index_driver.add_blank_record(
-        did=did,
-        uploader=uploader,
-        baseid=baseid
+        uploader=uploader
     )
+
     ret = {
         'did': did,
         'rev': rev,

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -267,9 +267,9 @@ def post_index_record():
 
 @blueprint.route('/index/blank/', methods=['POST'])
 @authorize
-def post_index_empty_record():
+def post_index_blank_record():
     '''
-    Create an empty new record with only uploader field is filled
+    Create a blank new record with only uploader field is filled
     '''
 
     uploader = flask.request.json.get('uploader')
@@ -301,19 +301,21 @@ def post_index_empty_record():
 
 @blueprint.route('/index/blank/<path:record>', methods=['PUT'])
 @authorize
-def put_index_empty_record(record):
+def put_index_blank_record(record):
     '''
-    Update an empty new record with size and hashes
+    Update an blank new record with size, hashes and url
     '''
     rev = flask.request.args.get('rev')
     size = flask.request.json.get('size')
     hashes = flask.request.json.get('hashes')
+    urls = flask.request.json.get('urls')
 
     did, rev, baseid = blueprint.index_driver.update_blank_record(
         did=record,
         rev=rev,
         size=size,
         hashes=hashes,
+        urls=urls,
     )
     ret = {
         'did': did,

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -265,6 +265,7 @@ def post_index_record():
 
     return flask.jsonify(ret), 200
 
+
 @blueprint.route('/index/blank/', methods=['POST'])
 @authorize
 def post_index_blank_record():
@@ -275,9 +276,6 @@ def post_index_blank_record():
     uploader = flask.request.json.get('uploader')
     if not uploader:
         raise UserError('no uploader specified')
-
-    baseid = flask.request.json.get('baseid')
-    did = flask.request.json.get('did')
 
     did, rev, baseid = blueprint.index_driver.add_blank_record(
         uploader=uploader
@@ -291,19 +289,12 @@ def post_index_blank_record():
 
     return flask.jsonify(ret), 200
 
-# @blueprint.route('/index/blank/<path:uploader>', methods=['GET'])
-# @authorize
-# def get_index_record_with_empty_acl(uploader):
-#     '''
-#     Get list of index record with empty acl
-#     '''
-
 
 @blueprint.route('/index/blank/<path:record>', methods=['PUT'])
 @authorize
 def put_index_blank_record(record):
     '''
-    Update an blank new record with size, hashes and url
+    Update a blank record with size, hashes and url
     '''
     rev = flask.request.args.get('rev')
     size = flask.request.json.get('size')
@@ -324,6 +315,7 @@ def put_index_blank_record(record):
     }
 
     return flask.jsonify(ret), 200
+
 
 @blueprint.route('/index/<path:record>', methods=['PUT'])
 @authorize

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -263,7 +263,7 @@ def post_index_record():
 
     return flask.jsonify(ret), 200
 
-@blueprint.route('/index/empty/', methods=['POST'])
+@blueprint.route('/index/blank/', methods=['POST'])
 @authorize
 def post_index_empty_record():
     '''
@@ -273,7 +273,7 @@ def post_index_empty_record():
     uploader = flask.request.json.get('uploader')
     baseid = flask.request.json.get('baseid')
 
-    did = blueprint.index_driver.add_blank_record(
+    did, rev = blueprint.index_driver.add_blank_record(
         uploader=uploader,
         baseid=baseid
     )

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -272,18 +272,52 @@ def post_index_empty_record():
 
     uploader = flask.request.json.get('uploader')
     baseid = flask.request.json.get('baseid')
+    did = flask.request.json.get('did')
 
-    did, rev = blueprint.index_driver.add_blank_record(
+    did, rev, baseid = blueprint.index_driver.add_blank_record(
+        did=did,
         uploader=uploader,
         baseid=baseid
     )
     ret = {
         'did': did,
-        'rev': rev
+        'rev': rev,
+        'baseid': baseid,
     }
 
     return flask.jsonify(ret), 200
 
+# @blueprint.route('/index/blank/<path:record>', methods=['GET'])
+# @authorize
+# def get_index_record_with_empty_acl(record):
+#     '''
+#     Get an index record with empty acl
+#     '''
+#     pass
+
+@blueprint.route('/index/blank/<path:record>', methods=['PUT'])
+@authorize
+def put_index_empty_record(record):
+    '''
+    Update an empty new record with size and hashes
+    '''
+    rev = flask.request.args.get('rev')
+    size = flask.request.json.get('size')
+    hashes = flask.request.json.get('hashes')
+
+    did, rev, baseid = blueprint.index_driver.update_blank_record(
+        did=record,
+        rev=rev,
+        size=size,
+        hashes=hashes,
+    )
+    ret = {
+        'did': did,
+        'rev': rev,
+        'baseid': baseid,
+    }
+
+    return flask.jsonify(ret), 200
 
 @blueprint.route('/index/<path:record>', methods=['PUT'])
 @authorize

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -263,6 +263,27 @@ def post_index_record():
 
     return flask.jsonify(ret), 200
 
+@blueprint.route('/index/empty/', methods=['POST'])
+@authorize
+def post_index_empty_record():
+    '''
+    Create an empty new record with only uploader field is filled
+    '''
+
+    uploader = flask.request.json.get('uploader')
+    baseid = flask.request.json.get('baseid')
+
+    did = blueprint.index_driver.add_blank_record(
+        uploader=uploader,
+        baseid=baseid
+    )
+    ret = {
+        'did': did,
+        'rev': rev
+    }
+
+    return flask.jsonify(ret), 200
+
 
 @blueprint.route('/index/<path:record>', methods=['PUT'])
 @authorize

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -96,7 +96,7 @@ def get_index():
 
     acl = flask.request.args.get('acl')
     if acl is not None:
-        acl = [] if acl == '' else acl.split(',')
+        acl = [] if acl == 'null' else acl.split(',')
 
     urls_metadata = flask.request.args.get('urls_metadata')
     if urls_metadata:

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -273,7 +273,7 @@ def post_index_blank_record():
     Create a blank new record with only uploader field is filled
     '''
 
-    uploader = flask.request.json.get('uploader')
+    uploader = flask.request.get_json().get('uploader')
     if not uploader:
         raise UserError('no uploader specified')
 
@@ -287,7 +287,7 @@ def post_index_blank_record():
         'baseid': baseid,
     }
 
-    return flask.jsonify(ret), 200
+    return flask.jsonify(ret), 201
 
 
 @blueprint.route('/index/blank/<path:record>', methods=['PUT'])
@@ -297,9 +297,9 @@ def put_index_blank_record(record):
     Update a blank record with size, hashes and url
     '''
     rev = flask.request.args.get('rev')
-    size = flask.request.json.get('size')
-    hashes = flask.request.json.get('hashes')
-    urls = flask.request.json.get('urls')
+    size = flask.request.get_json().get('size')
+    hashes = flask.request.get_json().get('hashes')
+    urls = flask.request.get_json().get('urls')
 
     did, rev, baseid = blueprint.index_driver.update_blank_record(
         did=record,

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -81,8 +81,6 @@ def get_index():
     # TODO: Based on indexclient, url here should be urls instead. Or change urls to url in indexclient.
     urls = flask.request.args.getlist('url')
 
-    acl = flask.request.args.getlist('acl')
-
     file_name = flask.request.args.get('file_name')
 
     version = flask.request.args.get('version')
@@ -95,6 +93,9 @@ def get_index():
 
     metadata = flask.request.args.getlist('metadata')
     metadata = {k: v for k, v in map(lambda x: x.split(':', 1), metadata)}
+
+    acl = flask.request.args.get('acl')
+    acl = [] if acl == '' else acl.split(',')
 
     urls_metadata = flask.request.args.get('urls_metadata')
     if urls_metadata:
@@ -287,13 +288,13 @@ def post_index_empty_record():
 
     return flask.jsonify(ret), 200
 
-# @blueprint.route('/index/blank/<path:record>', methods=['GET'])
+# @blueprint.route('/index/blank/<path:uploader>', methods=['GET'])
 # @authorize
-# def get_index_record_with_empty_acl(record):
+# def get_index_record_with_empty_acl(uploader):
 #     '''
-#     Get an index record with empty acl
+#     Get list of index record with empty acl
 #     '''
-#     pass
+
 
 @blueprint.route('/index/blank/<path:record>', methods=['PUT'])
 @authorize

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -95,7 +95,7 @@ def get_index():
     metadata = {k: v for k, v in map(lambda x: x.split(':', 1), metadata)}
 
     acl = flask.request.args.get('acl')
-    if acl:
+    if acl is not None:
         acl = [] if acl == '' else acl.split(',')
 
     urls_metadata = flask.request.args.get('urls_metadata')

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -656,12 +656,13 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             return record.did, record.rev, record.baseid
     
-    def update_blank_record(self, did, rev, size, hashes):
+    def update_blank_record(self, did, rev, size, hashes, urls):
         """
         Update a blank record with size and hashes, raise exception
         if the record is non-empty or the revision is not matched
         """
         hashes = hashes or {}
+        urls = urls or []
 
         if not size or not hashes:
             raise UserError("No size or hashes provided")
@@ -688,6 +689,10 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 hash_type=h,
                 hash_value=v,
             ) for h, v in hashes.items()]
+            record.urls = [IndexRecordUrl(
+                did=record.did,
+                url=url,
+            ) for url in urls]
 
             record.rev = str(uuid.uuid4())[:8]
 

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -676,13 +676,13 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 raise NoRecordFound('no record found')
             except MultipleResultsFound:
                 raise MultipleRecordsFound('multiple records found')
-            
+
             if record.size or record.hashes:
-                raise UserError("update is not supported for non-empty record!")
+                raise UserError("update api is not supported for non-empty record!")
 
             if rev != record.rev:
                 raise RevisionMismatch('revision mismatch')
-            
+
             record.size = size
             record.hashes = [IndexRecordHash(
                 did=record.did,

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -642,7 +642,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             baseid = str(uuid.uuid4())
             if self.config.get('PREPEND_PREFIX'):
                 did = self.config['DEFAULT_PREFIX'] + did
-            
+
             record.did = did
             base_version.baseid = baseid
 
@@ -655,7 +655,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             session.commit()
 
             return record.did, record.rev, record.baseid
-    
+
     def update_blank_record(self, did, rev, size, hashes, urls):
         """
         Update a blank record with size and hashes, raise exception
@@ -864,7 +864,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Add a record version given did
         """
-        urlrs = urls or []
+        urls = urls or []
         acl = acl or []
         hashes = hashes or {}
         metadata = metadata or {}

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -637,7 +637,6 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Create a new blank record with only
         """
-
         with self.session as session:
             record = IndexRecord()
             base_version = BaseVersion()
@@ -653,7 +652,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             record.did = new_did
             record.rev = str(uuid.uuid4())[:8]
             record.baseid = baseid
-            #record.uploader = uploader
+            record.uploader = uploader
             
             session.merge(base_version)
             session.add(record)

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -633,6 +633,33 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             return record.did, record.rev, record.baseid
 
+    def add_blank_record(self, uploader=uploader, baseid=baseid):
+        """
+        Create a new blank record with only
+        """
+        with self.session as session:
+            record = IndexRecord()
+            base_version = BaseVersion()
+
+            if not baseid:
+                baseid = str(uuid.uuid4())
+            base_version.baseid = baseid
+
+            new_did = str(uuid.uuid4())
+            if self.config.get('PREPEND_PREFIX'):
+                new_did = self.config['DEFAULT_PREFIX'] + new_did
+            
+            record.did = new_did
+            record.rev = str(uuid.uuid4())[:8]
+            record.baseid = baseid
+            record.uploader = uploader
+            
+            session.merge(base_version)
+            session.add(record)
+            session.commit()
+
+            return record.did
+
     def add_prefix_alias(self, record, session):
         """
         Create a index alias with the alias as {prefix:did}

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -658,7 +658,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             record.rev = str(uuid.uuid4())[:8]
             record.baseid = baseid
             record.uploader = uploader
-            
+
             session.merge(base_version)
             session.add(record)
             session.commit()

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -632,7 +632,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
     def add_blank_record(self, uploader):
         """
-        Create a new blank record with only
+        Create a new blank record with only uploader field is filled
         """
         with self.session as session:
             record = IndexRecord()

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -354,17 +354,19 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             if uploader is not None:
                 query = query.filter(IndexRecord.uploader == uploader)
 
-            if urls is not None and urls:
+            if urls:
                 query = query.join(IndexRecord.urls)
                 for u in urls:
                     query = query.filter(IndexRecordUrl.url == u)
 
-            if acl is not None and acl:
+            if acl:
                 query = query.join(IndexRecord.acl)
                 for u in acl:
                     query = query.filter(IndexRecordACE.ace == u)
+            elif acl == []:
+                query = query.filter(IndexRecord.acl == None)
 
-            if hashes is not None and hashes:
+            if hashes:
                 for h, v in hashes.items():
                     sub = session.query(IndexRecordHash.did)
                     sub = sub.filter(and_(
@@ -373,7 +375,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                     ))
                     query = query.filter(IndexRecord.did.in_(sub.subquery()))
 
-            if metadata is not None and metadata:
+            if metadata:
                 for k, v in metadata.items():
                     sub = session.query(IndexRecordMetadata.did)
                     sub = sub.filter(

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -633,10 +633,11 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             return record.did, record.rev, record.baseid
 
-    def add_blank_record(self, uploader=uploader, baseid=baseid):
+    def add_blank_record(self, uploader=None, baseid=None):
         """
         Create a new blank record with only
         """
+
         with self.session as session:
             record = IndexRecord()
             base_version = BaseVersion()
@@ -652,13 +653,13 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             record.did = new_did
             record.rev = str(uuid.uuid4())[:8]
             record.baseid = baseid
-            record.uploader = uploader
+            #record.uploader = uploader
             
             session.merge(base_version)
             session.add(record)
             session.commit()
 
-            return record.did
+            return record.did, record.rev
 
     def add_prefix_alias(self, record, session):
         """

--- a/indexd/index/errors.py
+++ b/indexd/index/errors.py
@@ -17,7 +17,6 @@ class RevisionMismatch(BaseIndexError):
     '''
     Revision mismatch.
     '''
-
 class UnhealthyCheck(BaseIndexError):
     '''
     Health check failed.

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -173,6 +173,11 @@ paths:
           description: comma delimited urls
           required: false
           type: string
+        - name: acl
+          in: query
+          description: comma delimited ace
+          required: false
+          type: string
         - name: negate_params
           in: query
           description: |

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -261,7 +261,7 @@ paths:
         '200':
           description: successful operation
           schema:
-            $ref: '#/definitions/OutputInfo'
+            $ref: '#/definitions/OutputRef'
         '400':
           description: Invalid status value
       security:
@@ -973,8 +973,8 @@ definitions:
   InputBlankInfo:
     type: object
     properties:
-      baseid:
-        $ref: "#/definitions/UUID"
+      uploader:
+        type: string
   UpdateInputInfo:
     type: object
     properties:
@@ -1005,6 +1005,10 @@ definitions:
         type: integer
       hashes:
         $ref: '#/definitions/HashInfo'
+      urls:
+        type: array
+        items:
+          type: string
   OutputRef:
     type: object
     properties:

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -236,6 +236,31 @@ paths:
               hashes:
                 $ref: '#/definitions/HashInfo'
       security: []
+  '/index/blank':
+    post:
+      tags:
+        - index
+      summary: Create a blank record
+      description: ''
+      operationId: createBlankEntry
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Metadata object that needs to be added to the store
+          required: true
+          schema:
+            $ref: '#/definitions/InputBlankInfo'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/OutputInfo'
+        '400':
+          description: Invalid status value
+      security:
+        - basic_auth: []
   '/index/{UUID}':
     get:
       tags:
@@ -903,6 +928,11 @@ definitions:
           type: string
       hashes:
         $ref: '#/definitions/HashInfo'
+  InputBlankInfo:
+    type: object
+    properties:
+      baseid:
+        $ref: "#/definitions/UUID"
   UpdateInputInfo:
     type: object
     properties:

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -261,6 +261,43 @@ paths:
           description: Invalid status value
       security:
         - basic_auth: []
+  '/index/blank/{UUID}':
+    put:
+      tags:
+        - index
+      summary: Update only hashes and size for blank index
+      description: ''
+      operationId: updateBlankEntry
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: UUID
+          in: path
+          description: entry id
+          required: true
+          type: string
+        - name: rev
+          in: query
+          description: data revision - simple consistency mechanism
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: index record that needs to be updated
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateBlankInputInfo'
+      responses:
+        '200':
+          description: success
+          schema:
+            $ref: '#/definitions/OutputRef'
+        '400':
+          description: Invalid input
+      security:
+        - basic_auth: []
   '/index/{UUID}':
     get:
       tags:
@@ -956,6 +993,13 @@ definitions:
         type: array
         items:
           type: string
+  UpdateBlankInputInfo:
+    type: object
+    properties:
+      size:
+        type: integer
+      hashes:
+        $ref: '#/definitions/HashInfo'
   OutputRef:
     type: object
     properties:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -142,7 +142,7 @@ def test_list_entries_with_uploader(swg_index_client):
     """
     data = get_doc()
     data['uploader'] = 'uploader_1'
-    r1 = swg_index_client.add_entry(data)
+    swg_index_client.add_entry(data)
 
     data = get_doc()
     data['uploader'] = 'uploader_123'
@@ -192,7 +192,7 @@ def test_create_blank_record(swg_index_client):
     assert r.records[0].did
     assert not r.records[0].size
     assert not r.records[0].acl
-    
+
     assert not r.records[0].hashes.crc
     assert not r.records[0].hashes.md5
     assert not r.records[0].hashes.sha
@@ -239,7 +239,7 @@ def test_get_empty_acl_record(swg_index_client):
     r = swg_index_client.list_entries()
     assert len(r.records) == 3
 
-    r = swg_index_client.list_entries(uploader='uploader_123', acl='')
+    r = swg_index_client.list_entries(uploader='uploader_123', acl='null')
 
     assert len(r.records) == 2
     assert {r2.did, r3.did} == {r.records[0].did, r.records[1].did}
@@ -262,6 +262,7 @@ def test_get_empty_acl_record_after_fill_size_n_hash(swg_index_client):
     r1 = swg_index_client.update_entry(r1.did, rev=r1.rev, body={'acl': ['read']})
     r1 = swg_index_client.get_entry(r1.did)
     assert r1.acl == ['read']
+    assert r1.did == did1
 
     # create the second blank record, only update size hashes and urls
     doc = {'uploader': 'uploader_123'}
@@ -283,19 +284,19 @@ def test_get_empty_acl_record_after_fill_size_n_hash(swg_index_client):
         'urls': ['s3://example/2'],
     }
     swg_index_client.update_blank_entry(r3.did, rev=r3.rev, body=updated)
-    
+
     r = swg_index_client.list_entries(uploader='uploader_123')
     assert len(r.records) == 3
 
     r = swg_index_client.list_entries(uploader='uploader_123', acl='read')
     assert len(r.records) == 1
-    r.records[0].did == r1.did
+    assert r.records[0].did == r1.did
 
 
     r = swg_index_client.list_entries(uploader='uploader_123', acl='write')
     assert len(r.records) == 0
 
-    r = swg_index_client.list_entries(uploader='uploader_123', acl='')
+    r = swg_index_client.list_entries(uploader='uploader_123', acl='null')
     assert len(r.records) == 2
     assert {r.records[0].did, r.records[1].did} == {did2, did3}
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -203,8 +203,13 @@ def test_get_empty_acl_record(swg_index_client):
     doc = {'uploader': 'uploader_123'}
     r = swg_index_client.create_blank_entry(doc)
 
-    assert r.did
-    assert r.rev
+    doc = {'uploader': 'uploader_123'}
+    r = swg_index_client.create_blank_entry(doc)
+
+    r = swg_index_client.list_entries(acl='')
+    assert len(r.records) == 2
+    assert r.records[0].acl == []
+    assert r.records[1].acl == []
 
 def test_urls_metadata(swg_index_client):
     data = get_doc(has_urls_metadata=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -157,22 +157,54 @@ def test_list_entries_with_uploader(swg_index_client):
 
 def test_create_blank_record(swg_index_client):
     doc = {'uploader': 'uploader_123'}
+
     r = swg_index_client.create_blank_entry(doc)
     assert r.did
     assert r.rev
+    assert r.baseid
 
     r = swg_index_client.list_entries(uploader='uploader_123')
+
     assert r.records[0].uploader == 'uploader_123'
     assert r.records[0].baseid
     assert r.records[0].did
     assert not r.records[0].size 
     assert not r.records[0].acl
+    
     assert not r.records[0].hashes.crc
     assert not r.records[0].hashes.md5
     assert not r.records[0].hashes.sha
     assert not r.records[0].hashes.sha256
     assert not r.records[0].hashes.sha512
 
+def test_fill_size_n_hash_for_blank_record(swg_index_client):
+    doc = {'uploader': 'uploader_123'}
+
+    r = swg_index_client.create_blank_entry(doc)
+    assert r.did
+    assert r.rev
+
+    did, rev = r.did, r.rev
+    updated = {
+        'size': 10,
+        'hashes': {'md5': '8b9942cf415384b27cadf1f4d2d981f5'},
+    }
+
+    r = swg_index_client.update_blank_entry(did, rev=rev, body=updated)
+    assert r.did == did
+    assert r.rev != rev
+
+    r = swg_index_client.get_entry(did)
+    assert r.size == 10
+    assert r.hashes.md5 == '8b9942cf415384b27cadf1f4d2d981f5'
+
+
+def test_get_empty_acl_record(swg_index_client):
+    doc = {'uploader': 'uploader_123'}
+    r = swg_index_client.create_blank_entry(doc)
+
+    assert r.did
+    assert r.rev
 
 def test_urls_metadata(swg_index_client):
     data = get_doc(has_urls_metadata=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -179,7 +179,6 @@ def test_list_entries_with_uploader_wrong_uploader(swg_index_client):
 
 def test_create_blank_record(swg_index_client):
     doc = {'uploader': 'uploader_123'}
-
     r = swg_index_client.create_blank_entry(doc)
     assert r.did
     assert r.rev

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -269,7 +269,6 @@ def test_index_get(swg_index_client):
 def test_index_prepend_prefix(swg_index_client):
     data = get_doc()
 
-
     result = swg_index_client.add_entry(data)
     r = swg_index_client.get_entry(result.did)
     assert r.did == result.did
@@ -404,6 +403,20 @@ def test_index_create_with_version(swg_index_client):
     r = swg_index_client.get_entry(r.did)
     assert r.version == data['version']
 
+def test_index_create_blank_record(swg_index_client):
+    doc = {
+        'uploader': 'uploader_123',
+        'baseid': 'baseid_123'
+    }
+
+    r = swg_index_client.create_blank_entry(doc)
+    assert r.did
+    res = swg_index_client.get_entry(r.did)
+    assert res.acl==[]
+    assert res.urls_metadata == {}
+    assert res.size is None
+    assert res.version is None
+    assert res.urls_metadata == {}
 
 def test_index_create_with_uploader(swg_index_client):
     data = get_doc()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -198,15 +198,49 @@ def test_fill_size_n_hash_for_blank_record(swg_index_client):
     assert r.size == 10
     assert r.hashes.md5 == '8b9942cf415384b27cadf1f4d2d981f5'
 
+def test_get_no_empty_acl_record(swg_index_client):
+    doc = {'uploader': 'uploader_123'}
+    r1 = swg_index_client.create_blank_entry(doc)
+    updated = {
+        'size': 10,
+        'hashes': {'md5': '8b9942cf415384b27cadf1f4d2d981f5'},
+    }
+
+    r1 = swg_index_client.update_blank_entry(r1.did, rev=r1.rev, body=updated)
+    r1 = swg_index_client.update_entry(r1.did, rev=r1.rev, body={'acl': ['read']})
+    r1 = swg_index_client.get_entry(r1.did)
+    assert r1.acl == ['read']
+
+    doc = {'uploader': 'uploader_123'}
+    r2 = swg_index_client.create_blank_entry(doc)
+    updated = {
+        'size': 4,
+        'hashes': {'md5': '1b9942cf415384b27cadf1f4d2d981f5'},
+    }
+    r1 = swg_index_client.update_blank_entry(r1.did, rev=r1.rev, body=updated)
+    r = swg_index_client.list_entries(uploader='uploader_123', acl='')
+    assert len(r.records) == 1
+
+
+
 
 def test_get_empty_acl_record(swg_index_client):
-    doc = {'uploader': 'uploader_123'}
-    r = swg_index_client.create_blank_entry(doc)
+    """
+    Test that can get a list of empty acl given uploader
+    """
+    doc = get_doc()
+    r = swg_index_client.add_entry(doc)
 
     doc = {'uploader': 'uploader_123'}
     r = swg_index_client.create_blank_entry(doc)
 
-    r = swg_index_client.list_entries(acl='')
+    doc = {'uploader': 'uploader_123'}
+    r = swg_index_client.create_blank_entry(doc)
+
+    r = swg_index_client.list_entries()
+    assert len(r.records) == 3
+
+    r = swg_index_client.list_entries(uploader='uploader_123', acl='')
     assert len(r.records) == 2
     assert r.records[0].acl == []
     assert r.records[1].acl == []

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -137,6 +137,9 @@ def test_index_list_with_params_negate(swg_index_client):
     assert ids == {r_3.did, r_4.did, r_5.did}
 
 def test_list_entries_with_uploader(swg_index_client):
+    """
+    Test that return a list of record given uploader
+    """
     data = get_doc()
     data['uploader'] = 'uploader_1'
     r = swg_index_client.add_entry(data)
@@ -154,6 +157,25 @@ def test_list_entries_with_uploader(swg_index_client):
     assert r.records[0].uploader == 'uploader_123'
     assert r.records[1].uploader == 'uploader_123'
 
+def test_list_entries_with_uploader_wrong_uploader(swg_index_client):
+    """
+    Test that returns no record due to wrong uploader id
+    """
+    data = get_doc()
+    data['uploader'] = 'uploader_1'
+    r = swg_index_client.add_entry(data)
+
+    data = get_doc()
+    data['uploader'] = 'uploader_123'
+    r = swg_index_client.add_entry(data)
+
+    data = get_doc()
+    data['uploader'] = 'uploader_123'
+    r = swg_index_client.add_entry(data)
+
+    r = swg_index_client.list_entries(uploader='wrong_uploader')
+    assert len(r.records) == 0
+
 
 def test_create_blank_record(swg_index_client):
     doc = {'uploader': 'uploader_123'}
@@ -168,7 +190,7 @@ def test_create_blank_record(swg_index_client):
     assert r.records[0].uploader == 'uploader_123'
     assert r.records[0].baseid
     assert r.records[0].did
-    assert not r.records[0].size 
+    assert not r.records[0].size
     assert not r.records[0].acl
     
     assert not r.records[0].hashes.crc
@@ -178,6 +200,9 @@ def test_create_blank_record(swg_index_client):
     assert not r.records[0].hashes.sha512
 
 def test_fill_size_n_hash_for_blank_record(swg_index_client):
+    """
+    Test that can fill size and hashes for empty record
+    """
     doc = {'uploader': 'uploader_123'}
 
     r = swg_index_client.create_blank_entry(doc)
@@ -197,32 +222,6 @@ def test_fill_size_n_hash_for_blank_record(swg_index_client):
     r = swg_index_client.get_entry(did)
     assert r.size == 10
     assert r.hashes.md5 == '8b9942cf415384b27cadf1f4d2d981f5'
-
-def test_get_no_empty_acl_record(swg_index_client):
-    doc = {'uploader': 'uploader_123'}
-    r1 = swg_index_client.create_blank_entry(doc)
-    updated = {
-        'size': 10,
-        'hashes': {'md5': '8b9942cf415384b27cadf1f4d2d981f5'},
-    }
-
-    r1 = swg_index_client.update_blank_entry(r1.did, rev=r1.rev, body=updated)
-    r1 = swg_index_client.update_entry(r1.did, rev=r1.rev, body={'acl': ['read']})
-    r1 = swg_index_client.get_entry(r1.did)
-    assert r1.acl == ['read']
-
-    doc = {'uploader': 'uploader_123'}
-    r2 = swg_index_client.create_blank_entry(doc)
-    updated = {
-        'size': 4,
-        'hashes': {'md5': '1b9942cf415384b27cadf1f4d2d981f5'},
-    }
-    r1 = swg_index_client.update_blank_entry(r1.did, rev=r1.rev, body=updated)
-    r = swg_index_client.list_entries(uploader='uploader_123', acl='')
-    assert len(r.records) == 1
-
-
-
 
 def test_get_empty_acl_record(swg_index_client):
     """
@@ -244,6 +243,32 @@ def test_get_empty_acl_record(swg_index_client):
     assert len(r.records) == 2
     assert r.records[0].acl == []
     assert r.records[1].acl == []
+
+def test_get_empty_acl_record_after_fill_size_n_hash(swg_index_client):
+    """
+    Test create blank record -> fill hash and size -> get record with empty acl
+    """
+    doc = {'uploader': 'uploader_123'}
+    r1 = swg_index_client.create_blank_entry(doc)
+    updated = {
+        'size': 10,
+        'hashes': {'md5': '8b9942cf415384b27cadf1f4d2d981f5'},
+    }
+
+    r1 = swg_index_client.update_blank_entry(r1.did, rev=r1.rev, body=updated)
+    r1 = swg_index_client.update_entry(r1.did, rev=r1.rev, body={'acl': ['read']})
+    r1 = swg_index_client.get_entry(r1.did)
+    assert r1.acl == ['read']
+
+    doc = {'uploader': 'uploader_123'}
+    r2 = swg_index_client.create_blank_entry(doc)
+    updated = {
+        'size': 4,
+        'hashes': {'md5': '1b9942cf415384b27cadf1f4d2d981f5'},
+    }
+    swg_index_client.update_blank_entry(r2.did, rev=r2.rev, body=updated)
+    r = swg_index_client.list_entries(uploader='uploader_123', acl='')
+    assert len(r.records) == 1
 
 def test_urls_metadata(swg_index_client):
     data = get_doc(has_urls_metadata=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -142,18 +142,19 @@ def test_list_entries_with_uploader(swg_index_client):
     """
     data = get_doc()
     data['uploader'] = 'uploader_1'
-    r = swg_index_client.add_entry(data)
+    r1 = swg_index_client.add_entry(data)
 
     data = get_doc()
     data['uploader'] = 'uploader_123'
-    r = swg_index_client.add_entry(data)
+    r2 = swg_index_client.add_entry(data)
 
     data = get_doc()
     data['uploader'] = 'uploader_123'
-    r = swg_index_client.add_entry(data)
+    r3 = swg_index_client.add_entry(data)
 
     r = swg_index_client.list_entries(uploader='uploader_123')
     assert len(r.records) == 2
+    assert {r2.did, r3.did} == {r.records[0].did, r.records[1].did}
     assert r.records[0].uploader == 'uploader_123'
     assert r.records[1].uploader == 'uploader_123'
 
@@ -230,44 +231,73 @@ def test_get_empty_acl_record(swg_index_client):
     r = swg_index_client.add_entry(doc)
 
     doc = {'uploader': 'uploader_123'}
-    r = swg_index_client.create_blank_entry(doc)
+    r2 = swg_index_client.create_blank_entry(doc)
 
     doc = {'uploader': 'uploader_123'}
-    r = swg_index_client.create_blank_entry(doc)
+    r3 = swg_index_client.create_blank_entry(doc)
 
     r = swg_index_client.list_entries()
     assert len(r.records) == 3
 
     r = swg_index_client.list_entries(uploader='uploader_123', acl='')
+
     assert len(r.records) == 2
+    assert {r2.did, r3.did} == {r.records[0].did, r.records[1].did}
     assert r.records[0].acl == []
     assert r.records[1].acl == []
 
 def test_get_empty_acl_record_after_fill_size_n_hash(swg_index_client):
     """
-    Test create blank record -> fill hash and size -> get record with empty acl
+    Test create blank record -> fill hash and size -> get record with empty or none acl
     """
+    # create the first blank record, update size, hashes and acl
     doc = {'uploader': 'uploader_123'}
     r1 = swg_index_client.create_blank_entry(doc)
     updated = {
         'size': 10,
         'hashes': {'md5': '8b9942cf415384b27cadf1f4d2d981f5'},
     }
-
+    did1 = r1.did
     r1 = swg_index_client.update_blank_entry(r1.did, rev=r1.rev, body=updated)
     r1 = swg_index_client.update_entry(r1.did, rev=r1.rev, body={'acl': ['read']})
     r1 = swg_index_client.get_entry(r1.did)
     assert r1.acl == ['read']
 
+    # create the second blank record, only update size hashes and urls
     doc = {'uploader': 'uploader_123'}
     r2 = swg_index_client.create_blank_entry(doc)
+    did2 = r2.did
     updated = {
         'size': 4,
         'hashes': {'md5': '1b9942cf415384b27cadf1f4d2d981f5'},
+        'urls': ['s3://example/1'],
     }
-    swg_index_client.update_blank_entry(r2.did, rev=r2.rev, body=updated)
-    r = swg_index_client.list_entries(uploader='uploader_123', acl='')
+
+    # create the second blank record, only update size hashes and urls
+    doc = {'uploader': 'uploader_123'}
+    r3 = swg_index_client.create_blank_entry(doc)
+    did3 = r3.did
+    updated = {
+        'size': 4,
+        'hashes': {'md5': '1b9942cf415384b27cadf1f4d2d981f5'},
+        'urls': ['s3://example/2'],
+    }
+    swg_index_client.update_blank_entry(r3.did, rev=r3.rev, body=updated)
+    
+    r = swg_index_client.list_entries(uploader='uploader_123')
+    assert len(r.records) == 3
+
+    r = swg_index_client.list_entries(uploader='uploader_123', acl='read')
     assert len(r.records) == 1
+    r.records[0].did == r1.did
+
+
+    r = swg_index_client.list_entries(uploader='uploader_123', acl='write')
+    assert len(r.records) == 0
+
+    r = swg_index_client.list_entries(uploader='uploader_123', acl='')
+    assert len(r.records) == 2
+    assert {r.records[0].did, r.records[1].did} == {did2, did3}
 
 def test_urls_metadata(swg_index_client):
     data = get_doc(has_urls_metadata=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -155,6 +155,25 @@ def test_list_entries_with_uploader(swg_index_client):
     assert r.records[1].uploader == 'uploader_123'
 
 
+def test_create_blank_record(swg_index_client):
+    doc = {'uploader': 'uploader_123'}
+    r = swg_index_client.create_blank_entry(doc)
+    assert r.did
+    assert r.rev
+
+    r = swg_index_client.list_entries(uploader='uploader_123')
+    assert r.records[0].uploader == 'uploader_123'
+    assert r.records[0].baseid
+    assert r.records[0].did
+    assert not r.records[0].size 
+    assert not r.records[0].acl
+    assert not r.records[0].hashes.crc
+    assert not r.records[0].hashes.md5
+    assert not r.records[0].hashes.sha
+    assert not r.records[0].hashes.sha256
+    assert not r.records[0].hashes.sha512
+
+
 def test_urls_metadata(swg_index_client):
     data = get_doc(has_urls_metadata=True)
     result = swg_index_client.add_entry(data)


### PR DESCRIPTION
New endpoint for blank records containing just the `uploader` field

- Allow creating empty records
- Query by empty acl
- Support filling (still not modifying) hash 

