### PR TITLE
Implement DRS v0.5.0 (closes #146)

### DIFF
--- a/indexd/dos/blueprint.py
+++ b/indexd/dos/blueprint.py
@@ -14,13 +14,13 @@ blueprint.index_driver = None
 blueprint.alias_driver = None
 blueprint.dist = []
 
+
 @blueprint.route('/ga4gh/dos/v1/dataobjects/<path:record>', methods=['GET'])
 def get_dos_record(record):
     '''
     Returns a record from the local ids, alias, or global resolvers.
     Returns DOS Schema
     '''
-
     try:
         ret = blueprint.index_driver.get(record)
         ret['alias'] = blueprint.index_driver.get_aliases_for_did(record)
@@ -38,14 +38,15 @@ def get_dos_record(record):
 
     return flask.jsonify(indexd_to_dos(ret)), 200
 
-@blueprint.route('/ga4gh/dos/v1/dataobjects/list', methods=['POST'])
+
+@blueprint.route('/ga4gh/dos/v1/dataobjects', methods=['GET'])
 def list_dos_records():
     '''
     Returns a record from the local ids, alias, or global resolvers.
     Returns DOS Schema
     '''
-    start = flask.request.json.get('page_token')
-    limit = flask.request.json.get('page_size')
+    start = flask.request.args.get('page_token')
+    limit = flask.request.args.get('page_size')
 
     try:
         limit = 100 if limit is None else int(limit)
@@ -55,13 +56,13 @@ def list_dos_records():
     if limit <= 0 or limit > 1024:
         raise UserError('limit must be between 1 and 1024')
 
-    url = flask.request.json.get('url')
+    url = flask.request.args.get('url')
 
     # Support this in the future when we have
     # more fully featured aliases?
-    #alias = flask.request.json.get('alias')
+    # alias = flask.request.args.get('alias')
 
-    checksum = flask.request.json.get('checksum')
+    checksum = flask.request.args.get('checksum')
     if checksum:
         hashes = {checksum['type']: checksum['checksum']}
     else:
@@ -80,6 +81,7 @@ def list_dos_records():
     ret = {"data_objects": [indexd_to_dos(record)['data_object'] for record in records]}
 
     return flask.jsonify(ret), 200
+
 
 def indexd_to_dos(record):
     data_object = {

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -595,8 +595,8 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/SystemStatsOutputRef'
-  /ga4gh/dos/v1/dataobjects/list:
-    post:
+  /ga4gh/dos/v1/dataobjects:
+    get:
       summary: List the Data Objects
       operationId: ListDataObjects
       responses:
@@ -621,11 +621,53 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
       parameters:
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/ListDataObjectsRequest'
+        - name: alias
+          in: query
+          type: string
+          required: false
+          description: |-
+            If provided will only return Data Objects with the given alias.
+        - name: url
+          in: query
+          type: string
+          required: false
+          description: |-
+            If provided will return only Data Objects with a that URL matches
+            this string.
+        - name: checksum
+          in: query
+          type: string
+          required: false
+          description: |-
+            The hexlified checksum that one would like to match on.
+        - name: checksum_type
+          in: query
+          type: string
+          required: false
+          description: |-
+            If provided will restrict responses to those that match the provided
+            type.
+            possible values:
+            md5                # most blob stores provide a checksum using this
+            multipart-md5      # multipart uploads provide a specialized tag in S3
+            sha256
+            sha512
+        - name: page_size
+          in: query
+          type: integer
+          format: int32
+          required: false
+          description: |-
+            Specifies the maximum number of results to return in a single page.
+            If unspecified, a system default will be used.
+        - name: page_token
+          in: query
+          type: string
+          required: false
+          description: |-
+            The continuation token, which is used to page through large result sets.
+            To get the next page of results, set this parameter to the value of
+            `next_page_token` from the previous response.
       tags:
         - DOS
   '/ga4gh/dos/v1/dataobjects/{DID}':
@@ -1080,45 +1122,39 @@ definitions:
         description: the accumulated size of the object files recorded in IndexD
   DataObject:
     type: object
+    required: ['id', 'size', 'created', 'checksums']
     properties:
       id:
         type: string
         description: |-
-          REQUIRED
           An identifier unique to this Data Object.
       name:
         type: string
         description: |-
-          OPTIONAL
           A string that can be optionally used to name a Data Object.
       size:
         type: string
         format: int64
         description: |-
-          REQUIRED
           The computed size in bytes.
       created:
         type: string
         format: date-time
         description: |-
-          REQUIRED
           Timestamp of object creation in RFC3339.
       updated:
         type: string
         format: date-time
         description: |-
-          OPTIONAL
           Timestamp of update in RFC3339, identical to create timestamp in systems
           that do not support updates.
       version:
         type: string
         description: |-
-          OPTIONAL
           A string representing a version.
       mime_type:
         type: string
         description: |-
-          OPTIONAL
           A string providing the mime-type of the Data Object.
           For example, "application/json".
       checksums:
@@ -1126,26 +1162,22 @@ definitions:
         items:
           $ref: '#/definitions/Checksum'
         description: |-
-          REQUIRED
           The checksum of the Data Object. At least one checksum must be provided.
       urls:
         type: array
         items:
           $ref: '#/definitions/URL'
         description: |-
-          OPTIONAL
           The list of URLs that can be used to access the Data Object.
       description:
         type: string
         description: |-
-          OPTIONAL
           A human readable description of the contents of the Data Object.
       aliases:
         type: array
         items:
           type: string
         description: |-
-          OPTIONAL
           A list of strings that can be used to find this Data Object.
           These aliases can be used to represent the Data Object's location in
           a directory (e.g. "bucket/folder/file.name") to make Data Objects
@@ -1156,31 +1188,35 @@ definitions:
       alias:
         type: string
         description: |-
-          OPTIONAL
           If provided will only return Data Objects with the given alias.
       url:
         type: string
         description: |-
-          OPTIONAL
           If provided will return only Data Objects with a that URL matches
           this string.
       checksum:
-        $ref: '#/definitions/ChecksumRequest'
+        type: string
         description: |-
-          OPTIONAL
-          If provided will only return data object messages with the provided
-          checksum. If the checksum type is provided
+          The hexlified checksum that one would like to match on.
+      checksum_type:
+        type: string
+        description: |-
+          If provided will restrict responses to those that match the provided
+          type.
+          possible values:
+          md5                # most blob stores provide a checksum using this
+          multipart-md5      # multipart uploads provide a specialized tag in S3
+          sha256
+          sha512
       page_size:
         type: integer
         format: int32
         description: |-
-          OPTIONAL
           Specifies the maximum number of results to return in a single page.
           If unspecified, a system default will be used.
       page_token:
         type: string
         description: |-
-          OPTIONAL
           The continuation token, which is used to page through large result sets.
           To get the next page of results, set this parameter to the value of
           `next_page_token` from the previous response.
@@ -1206,19 +1242,17 @@ definitions:
       token, that can be used to retrieve more results.
   GetDataObjectResponse:
     type: object
+    required: ['data_object']
     properties:
       data_object:
         $ref: '#/definitions/DataObject'
-        description: |-
-          REQUIRED
-          The Data Object that coincides with a specific GetDataObjectRequest.
   URL:
     type: object
+    required: ['url']
     properties:
       url:
         type: string
         description: |-
-          REQUIRED
           A URL that can be used to access the file.
       system_metadata:
         $ref: '#/definitions/SystemMetadata'
@@ -1252,16 +1286,15 @@ definitions:
             A set of key-value pairs that represent metadata provided by the uploader.
   Checksum:
     type: object
+    required: ['checksum']
     properties:
       checksum:
         type: string
         description: |-
-          REQUIRED
           The hex-string encoded checksum for the Data.
       type:
         type: string
         description: |-
-          OPTIONAL
           The digest method used to create the checksum. If left unspecified md5
           will be assumed.
           possible values:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -703,11 +703,12 @@ def test_dos_get(swg_index_client, swg_dos_client):
     r2 = swg_dos_client.get_data_object(result.baseid)
     assert r2.data_object.id == result.did
 
+
 def test_dos_list(swg_index_client, swg_dos_client):
     data = get_doc(has_urls_metadata=True, has_metadata=True, has_baseid=True)
 
     result = swg_index_client.add_entry(data)
-    r = swg_dos_client.list_data_objects(body={"page_size": 100})
+    r = swg_dos_client.list_data_objects(page_size=100)
     assert len(r.data_objects) == 1
     assert r.data_objects[0].id == result.did
     assert r.data_objects[0].size == "123"


### PR DESCRIPTION
This PR updates the behavior of DRS endpoints such that it reflects the changes and features introduced in v0.5.0 (from v0.2.0). The commit message has a few more details.

### New Features
* DRS v0.5.0 compliance

### Breaking Changes
* Functionality of `POST /dataobjects/list` has been moved to `GET /dataobjects`, and the parameters provided to this endpoint are now specified as query parameters instead of in the request body.

### Bug Fixes
None

### Improvements
* Specification of required and optional parameters has been properly serialized in the schema.
* `checksum` parameter is now optional for ListDataBundles and ListDataObjects.
* Minor changes for PEP8 compliance.


### Dependency updates
None

### Deployment changes
None

cc @david4096