### PR TITLE
Install gnupg2 for Docker tests (closes #187)

### DIFF
--- a/TestDockerfile
+++ b/TestDockerfile
@@ -3,6 +3,7 @@
 # in a self contained environment
 FROM python:2-slim
 
+RUN apt-get update && apt-get install -y gnupg2
 RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee /etc/apt/sources.list.d/webupd8team-java.list \
   && echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 \


### PR DESCRIPTION
Docker tests now run and all pass (except for `test_migrate_index_versioning`, which is noted in the README).

### New Features
None

### Breaking Changes
None

### Bug Fixes
* Fix Docker testing harness failing on start because `gnupg2` is not installed.

### Improvements
None

### Dependency updates
* `gnupg2` is now installed when running tests with Docker

### Deployment changes
None
