### PR TITLE
PXD-2415 Feat/file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For existing data in buckets, the SNS or PubSub notifications may be simulated s
 3. Indexing void object for fully control the bucket structure.
 
 Indexd supports void or blank records that allows users to pre-register data files in indexd before actually registering them. The complete flow contains three main steps: pre-register, hash/size/url populating and data node registration:
-- Fence requests blank object from indexd. Indexd creates an object with no hash, size, and urls except the `uploader` field.
+- Fence requests blank object from indexd. Indexd creates an object with no hash, size or urls, only the `uploader` and optionally `file_name` fields.
 - Indexd listener mornitors bucket update, update to indexd with url, hash, size.
 - The client application (windmill or gen3-data-client) lists records for data files which the user needs to submit to the graph. The user fills all empty fields and submit the request to indexd to update the `acl`.
 
@@ -43,7 +43,7 @@ https://github.com/uc-cdis/cdis-wiki/tree/master/dev/gen3/data_upload
 
 4. Using the Indexd REST API for record insertion.
 
-In rare cases, it may be necessary to interact directly with the Indexd API in order to create index records. This would be necessary if users are loading data into a data commons in non-standard ways or not utilizing Sheepdog as part of their data commons. 
+In rare cases, it may be necessary to interact directly with the Indexd API in order to create index records. This would be necessary if users are loading data into a data commons in non-standard ways or not utilizing Sheepdog as part of their data commons.
 
 ## Documentation
 
@@ -122,7 +122,7 @@ py.test -v tests/
 
 ## Testing with Docker
 
-Doesn't work with all the DB tests yet, but you can adjust to run specific tests as necessary. 
+Doesn't work with all the DB tests yet, but you can adjust to run specific tests as necessary.
 
 ```
 docker build -t indexd -f TestDockerfile .

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -270,15 +270,18 @@ def post_index_record():
 @authorize
 def post_index_blank_record():
     '''
-    Create a blank new record with only uploader field is filled
+    Create a blank new record with only uploader and optionally
+    file_name fields filled
     '''
 
     uploader = flask.request.get_json().get('uploader')
+    file_name = flask.request.get_json().get('file_name')
     if not uploader:
         raise UserError('no uploader specified')
 
     did, rev, baseid = blueprint.index_driver.add_blank_record(
-        uploader=uploader
+        uploader=uploader,
+        file_name=file_name
     )
 
     ret = {

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -630,9 +630,10 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             return record.did, record.rev, record.baseid
 
-    def add_blank_record(self, uploader):
+    def add_blank_record(self, uploader, file_name=None):
         """
-        Create a new blank record with only uploader field is filled
+        Create a new blank record with only uploader and optionally
+        file_name fields filled
         """
         with self.session as session:
             record = IndexRecord()
@@ -649,6 +650,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             record.rev = str(uuid.uuid4())[:8]
             record.baseid = baseid
             record.uploader = uploader
+            record.file_name = file_name
 
             session.add(base_version)
             session.add(record)

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -24,8 +24,8 @@ tags:
     externalDocs:
       description: Find out more
       url: 'https://github.com/uc-cdis/indexd'
-  - name: bulk 
-    description: bulk endpoints 
+  - name: bulk
+    description: bulk endpoints
   - name: query
     description: query endpoints
   - name: alias
@@ -42,12 +42,12 @@ tags:
 schemes:
   - https
 paths:
-  '/{GUID}':  
+  '/{GUID}':
     get:
       tags:
         - global
       summary: Get the metadata associated with the given id, alias, or distributed identifier
-      description: Only the hashes which exist will be included in the response. 
+      description: Only the hashes which exist will be included in the response.
       operationId: getEntry
       produces:
         - application/json
@@ -115,7 +115,7 @@ paths:
       parameters:
         - in: body
           name: body
-          description: Metadata object that needs to be added to the store. Providing at least one hash is necessary and sufficient. 
+          description: Metadata object that needs to be added to the store. Providing at least one hash is necessary and sufficient.
           required: true
           schema:
             $ref: '#/definitions/InputInfo'
@@ -207,8 +207,8 @@ paths:
       responses:
         '200':
           description: successful operation
-          schema: 
-            $ref: '#/definitions/ListRecords' 
+          schema:
+            $ref: '#/definitions/ListRecords'
       security: []
   '/index/blank':
     post:
@@ -299,7 +299,7 @@ paths:
         - index
       summary: >-
         Add new version for the document associated to the provided uuid.
-      description: Since data content is immutable, when you want to change the size or hash, a new index document with new uuid need to be created as its new version. That uuid is returned in the did field of the response. The old index document is not deleted. 
+      description: Since data content is immutable, when you want to change the size or hash, a new index document with new uuid need to be created as its new version. That uuid is returned in the did field of the response. The old index document is not deleted.
       operationId: addNewVersion
       produces:
         - application/json
@@ -694,8 +694,8 @@ paths:
         - DOS
   '/bulk/documents':
     post:
-      tags: 
-        - bulk 
+      tags:
+        - bulk
       summary: Get a list of documents given a list of dids
       operationId: getBulkIds
       produces:
@@ -935,6 +935,10 @@ definitions:
     properties:
       uploader:
         type: string
+        description: user who uploaded this file
+      file_name:
+        type: string
+        description: name of the uploaded file
   UpdateInputInfo:
     type: object
     properties:
@@ -1109,10 +1113,10 @@ definitions:
         type: string
         format: date-time
         description: last updated time
-      created_date: 
-        type: string 
-        format: date-time 
-        description: time created 
+      created_date:
+        type: string
+        format: date-time
+        description: time created
       metadata:
         type: object
         description: user defined optional metadata
@@ -1384,7 +1388,7 @@ definitions:
         description: number of aliases to return
       hashes:
         $ref: '#/definitions/HashInfo'
-  ListRecords:   
+  ListRecords:
     type: object
     properties:
       ids:
@@ -1419,11 +1423,10 @@ definitions:
           type: string
       hashes:
         $ref: '#/definitions/HashInfo'
-      metadata: 
+      metadata:
         type: object
       version:
-        type: string 
+        type: string
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'
-

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from util import assert_blank
 from indexd.index.blueprint import ACCEPTABLE_HASHES
 from swagger_client.rest import ApiException
 
@@ -181,21 +182,9 @@ def test_list_entries_with_uploader_wrong_uploader(swg_index_client):
 def test_create_blank_record(swg_index_client):
     """
     Test that new blank records only contain the uploader
-    and optionally file_name fields
+    and optionally file_name fields: test without file name
     """
 
-    def assert_blank(r):
-        assert r.records[0].baseid
-        assert r.records[0].did
-        assert not r.records[0].size
-        assert not r.records[0].acl
-        assert not r.records[0].hashes.crc
-        assert not r.records[0].hashes.md5
-        assert not r.records[0].hashes.sha
-        assert not r.records[0].hashes.sha256
-        assert not r.records[0].hashes.sha512
-
-    # file_name not provided
     doc = {
         'uploader': 'uploader_123'
     }
@@ -206,9 +195,15 @@ def test_create_blank_record(swg_index_client):
 
     r = swg_index_client.list_entries(uploader='uploader_123')
     assert r.records[0].uploader == 'uploader_123'
+    assert not r.records[0].file_name
     assert_blank(r)
 
-    # file_name provided
+def test_create_blank_record_with_file_name(swg_index_client):
+    """
+    Test that new blank records only contain the uploader
+    and optionally file_name fields: test with file name
+    """
+
     doc = {
         'uploader': 'uploader_321',
         'file_name': 'myfile.txt'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from util import assert_blank
+from tests.util import assert_blank
 from indexd.index.blueprint import ACCEPTABLE_HASHES
 from swagger_client.rest import ApiException
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -179,25 +179,49 @@ def test_list_entries_with_uploader_wrong_uploader(swg_index_client):
 
 
 def test_create_blank_record(swg_index_client):
-    doc = {'uploader': 'uploader_123'}
+    """
+    Test that new blank records only contain the uploader
+    and optionally file_name fields
+    """
+
+    def assert_blank(r):
+        assert r.records[0].baseid
+        assert r.records[0].did
+        assert not r.records[0].size
+        assert not r.records[0].acl
+        assert not r.records[0].hashes.crc
+        assert not r.records[0].hashes.md5
+        assert not r.records[0].hashes.sha
+        assert not r.records[0].hashes.sha256
+        assert not r.records[0].hashes.sha512
+
+    # file_name not provided
+    doc = {
+        'uploader': 'uploader_123'
+    }
     r = swg_index_client.create_blank_entry(doc)
     assert r.did
     assert r.rev
     assert r.baseid
 
     r = swg_index_client.list_entries(uploader='uploader_123')
-
     assert r.records[0].uploader == 'uploader_123'
-    assert r.records[0].baseid
-    assert r.records[0].did
-    assert not r.records[0].size
-    assert not r.records[0].acl
+    assert_blank(r)
 
-    assert not r.records[0].hashes.crc
-    assert not r.records[0].hashes.md5
-    assert not r.records[0].hashes.sha
-    assert not r.records[0].hashes.sha256
-    assert not r.records[0].hashes.sha512
+    # file_name provided
+    doc = {
+        'uploader': 'uploader_321',
+        'file_name': 'myfile.txt'
+    }
+    r = swg_index_client.create_blank_entry(doc)
+    assert r.did
+    assert r.rev
+    assert r.baseid
+
+    r = swg_index_client.list_entries(uploader='uploader_321')
+    assert r.records[0].uploader == 'uploader_321'
+    assert r.records[0].file_name == 'myfile.txt'
+    assert_blank(r)
 
 def test_fill_size_n_hash_for_blank_record(swg_index_client):
     """

--- a/tests/util.py
+++ b/tests/util.py
@@ -21,5 +21,21 @@ class removes(object):
                     shutil.rmtree(self.path)
                 elif os.path.isfile(self.path):
                     os.remove(self.path)
-        
+
         return wrapper
+
+
+def assert_blank(r):
+    '''
+    Check that the fields that should be empty in a
+    blank record are empty.
+    '''
+    assert r.records[0].baseid
+    assert r.records[0].did
+    assert not r.records[0].size
+    assert not r.records[0].acl
+    assert not r.records[0].hashes.crc
+    assert not r.records[0].hashes.md5
+    assert not r.records[0].hashes.sha
+    assert not r.records[0].hashes.sha256
+    assert not r.records[0].hashes.sha512


### PR DESCRIPTION
When users go see all the uploaded files in windmill, they should be able to see the file names.

### New Features
- Update the blank record creation endpoint in indexd to support providing the file name.

### Breaking Changes


### Bug Fixes


### Improvements
- indexd records created during the data upload flow will contain the file names.

### Dependency updates


### Deployment changes

