### PR TITLE
fix(api-568): eliminate duplicate ACLs

### DIFF
--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -900,7 +900,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             record.acl = [IndexRecordACE(
                 did=record.did,
                 ace=ace,
-            ) for ace in acl]
+            ) for ace in set(acl)]
 
             record.hashes = [IndexRecordHash(
                 did=record.did,


### PR DESCRIPTION
Eliminate the possibility of duplicate ACLs in the ACL list.

### Deployment changes
The database table `index_record_ace`'s primary key is (did, acl), so we shouldn't allow duplicates in the ACL list when making an IndexRecord. Using a set removes the duplicates.