### PR TITLE
bump sqlalchemy and sqlalchemy-utils; update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
+dist: trusty
 language: python
 
 python:
   - "2.7"
   - "3.4"
-addons:
-  apt:
-    packages:
-      - oracle-java9-set-default
 
 sudo: false
 
+before_install:
+    - jdk_switcher use oraclejdk8
 install:
     - "wget https://oss.sonatype.org/content/repositories/releases/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar"
     - "java -jar swagger-codegen-cli-2.3.1.jar generate -i openapis/swagger.yaml -l python -o swagger_client"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 
 python:
@@ -7,8 +7,12 @@ python:
 
 sudo: false
 
-before_install:
-    - jdk_switcher use oraclejdk8
+services:
+    - postgresql
+
+jdk:
+    - oraclejdk8
+
 install:
     - "wget https://oss.sonatype.org/content/repositories/releases/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar"
     - "java -jar swagger-codegen-cli-2.3.1.jar generate -i openapis/swagger.yaml -l python -o swagger_client"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 addons:
   apt:
     packages:
-      - oracle-java8-set-default
+      - oracle-java9-set-default
 
 sudo: false
 

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -10,8 +10,8 @@ RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | te
   && apt-get update && \
   mkdir -p /usr/share/man/man1/ \
   && apt-get install -y software-properties-common && \
-  (echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections) && \
-  apt-get install -y oracle-java8-set-default && \
+  (echo oracle-java9-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections) && \
+  apt-get install -y oracle-java9-set-default && \
   apt-get clean && \
   rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -10,8 +10,8 @@ RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | te
   && apt-get update && \
   mkdir -p /usr/share/man/man1/ \
   && apt-get install -y software-properties-common && \
-  (echo oracle-java9-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections) && \
-  apt-get install -y oracle-java9-set-default && \
+  (echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections) && \
+  apt-get install -y oracle-java8-set-default && \
   apt-get clean && \
   rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask==0.12.4
 jsonschema==2.5.1
-sqlalchemy==1.0.8
-sqlalchemy-utils>=0.32.21
+sqlalchemy==1.3.3
+sqlalchemy-utils>=0.33.11
 psycopg2>=2.7
 future>=0.16.0,<1.0.0
 git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging


### PR DESCRIPTION
tldr: bump sqlalchemy and sqlalchemy-utils. Also specify jdk 8 in .travis.yml. 
------------------------

Tried to just bump sqlalchemy and sqlalchemy-utils. Travis error:
```
Package oracle-java8-set-default is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  oracle-java9-set-default
```
Probably because: https://launchpad.net/~webupd8team/+archive/ubuntu/java 

The Travis dist was `trusty` (just because that is the default)(...[until tomorrow!](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment)). Switching from java8 to java9 worked, as did doing 
```
before_install:
  - jdk_switcher use oraclejdk8
``` 
in trusty. But we prefer `xenial`(and it's the new default), and we don't really care about jdk 8 or 9 so long as Swagger works, so settled on specifying 
```
dist: xenial
jdk: 
    - oraclejdk8
```

### Dependency updates
bump sqlalchemy from 1.0.8 to 1.3.3
bump sqlalchemy-utils from 0.32.21 to 0.33.11
