### PR TITLE
python 3 base v1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To run: docker run -v /path/to/wsgi.py:/var/www/indexd/wsgi.py --name=indexd -p 81:80 indexd
 # To check running container: docker exec -it indexd /bin/bash 
 
-FROM quay.io/cdis/python-nginx:pybase3-1.0.0
+FROM quay.io/cdis/python-nginx:pybase3-1.1.0
 
 
 ENV appname=indexd


### PR DESCRIPTION

### Improvements
- Use python 3 base dockerfile v1.1.0 to disable uwsgi cheaper mode
