### PR TITLE
Doc/prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ The `type` tells Indexd which client to use for that external service. In this c
 
 Indexd itself can be configured to append a prefix to the typical UUID in order to aide in the distributed resolution capabilities mentioned above. Specifically, we can add a prefix such as `dg.4GH5/` which may represent one instance of Indexd. For distributed resolution purposes, we can then create `hints` that let the central resolver know where to go when it receives a GUID with a prefix of `dg.4GH5/`.
 
-The prefix that a given Indexd instance uses is specified in the `DEFAULT_PREFIX` configuration in the settings file. In order to ensure that this gets used and aliases get created, specify `PREPEND_PREFIX` to `True` and `ADD_PREFIX_ALIAS` to `True` as well.
+The prefix that a given Indexd instance uses is specified in the `DEFAULT_PREFIX` configuration in the settings file. In order to ensure that this gets used, set `PREPEND_PREFIX` to `True`. Note that the prefix will only be prepended to GUIDs generated for new records that are indexed _without_ providing a GUID.
+
+The `ADD_PREFIX_ALIAS` configuration represents a different way of using the prefix: if set to `True`, instead of prepending the prefix to the GUID, indexd will create an alias of the form `<prefix><GUID>` for this record. Note that you should NOT set both `ADD_PREFIX_ALIAS` and `PREPEND_PREFIX` to `True`, or aliases will be created as `<prefix><prefix><GUID>`.
 
 ## Use Cases For Indexing Data
 

--- a/indexd/app.py
+++ b/indexd/app.py
@@ -27,17 +27,17 @@ def app_init(app, settings=None):
     app.register_blueprint(index_urls_blueprint, url_prefix="/_query/urls")
 
 
-def get_app():
+def get_app(settings=None):
     app = flask.Flask("indexd")
 
     if "INDEXD_SETTINGS" in os.environ:
         sys.path.append(os.environ["INDEXD_SETTINGS"])
 
-    settings = None
-    try:
-        from local_settings import settings
-    except ImportError:
-        pass
+    if not settings:
+        try:
+            from local_settings import settings
+        except ImportError:
+            pass
 
     app_init(app, settings)
 

--- a/indexd/default_settings.py
+++ b/indexd/default_settings.py
@@ -7,6 +7,12 @@ CONFIG = {}
 CONFIG["JSONIFY_PRETTYPRINT_REGULAR"] = False
 AUTO_MIGRATE = True
 
+# - DEFAULT_PREFIX: prefix to be prepended.
+# - PREPEND_PREFIX: the prefix is preprended to the generated GUID when a
+#   new record is created WITHOUT a provided GUID.
+# - ADD_PREFIX_ALIAS: aliases are created for new records - "<PREFIX><GUID>".
+# Do NOT set both ADD_PREFIX_ALIAS and PREPEND_PREFIX to True, or aliases
+# will be created as "<PREFIX><PREFIX><GUID>".
 CONFIG["INDEX"] = {
     "driver": SQLAlchemyIndexDriver(
         "sqlite:///index.sq3",
@@ -14,8 +20,8 @@ CONFIG["INDEX"] = {
         echo=True,
         index_config={
             "DEFAULT_PREFIX": "testprefix:",
-            "ADD_PREFIX_ALIAS": True,
             "PREPEND_PREFIX": True,
+            "ADD_PREFIX_ALIAS": False,
         },
     )
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,14 @@ from indexd import get_app
 import base64
 import pytest
 
+import importlib
+
 # indexd_server and indexd_client is needed as fixtures
 from cdisutilstest.code.conftest import indexd_server, indexd_client  # noqa
 from cdisutilstest.code.indexd_fixture import clear_database
 
-
 from indexd import auth
-import importlib
+from tests import default_test_settings
 
 
 @pytest.fixture
@@ -18,7 +19,8 @@ def app():
     from indexd import default_settings
 
     importlib.reload(default_settings)
-    yield get_app()
+
+    yield get_app(default_test_settings.settings)
     try:
         clear_database()
 

--- a/tests/default_test_settings.py
+++ b/tests/default_test_settings.py
@@ -1,0 +1,22 @@
+from indexd.default_settings import *
+from indexd.index.drivers.alchemy import SQLAlchemyIndexDriver
+
+# override the default settings for INDEX because we want to test
+# both PREPEND_PREFIX and ADD_PREFIX_ALIAS, which should not both
+# be set to True in production environments
+CONFIG["INDEX"] = {
+    "driver": SQLAlchemyIndexDriver(
+        "sqlite:///index.sq3",
+        auto_migrate=True,
+        echo=True,
+        index_config={
+            "DEFAULT_PREFIX": "testprefix:",
+            "PREPEND_PREFIX": True,
+            "ADD_PREFIX_ALIAS": True,
+        },
+    )
+}
+
+settings = {"config": CONFIG, "auth": AUTH}
+
+settings["config"]["TEST_DB"] = "postgres://postgres@localhost/test_migration_db"

--- a/tests/test_aliases_endpoints.py
+++ b/tests/test_aliases_endpoints.py
@@ -3,7 +3,6 @@ import string
 import json
 import urllib.parse
 
-from indexd import get_app
 
 # Test fixtures and helper functions
 # =============================================

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -892,6 +892,13 @@ def test_get_id(client, user):
 
 
 def test_index_prepend_prefix(client, user):
+    """
+    For index_config =
+    {
+        "DEFAULT_PREFIX": "testprefix:",
+        "PREPEND_PREFIX": True
+    }
+    """
     data = get_doc()
 
     res_1 = client.post("/index/", json=data, headers=user)
@@ -1128,6 +1135,21 @@ def test_index_get_global_endpoint(client, user):
     assert rec["size"] == data["size"]
     assert rec["urls"] == data["urls"]
     assert rec["hashes"]["md5"] == data["hashes"]["md5"]
+
+
+def test_index_add_prefix_alias(client, user):
+    """
+    For index_config =
+    {
+        "DEFAULT_PREFIX": "testprefix:",
+        "ADD_PREFIX_ALIAS": True
+    }
+    """
+    data = get_doc()
+
+    res = client.post("/index/", json=data, headers=user)
+    assert res.status_code == 200
+    rec = res.json
 
     res_2 = client.get("/testprefix:" + rec["did"])
     assert res_2.status_code == 200

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1,5 +1,5 @@
 import uuid
-from tests.test_settings import settings
+from tests.default_test_settings import settings
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 import sqlite3

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,0 @@
-from indexd.default_settings import settings
-
-settings["config"]["TEST_DB"] = "postgres://postgres@localhost/test_migration_db"


### PR DESCRIPTION
Rename `test_settings.py` to `default_test_settings.py` so that pytest doesn't think it's a test file.

Add optional `settings` parameter to `get_app()` to allow the tests to use a different config than the default one

### Improvements
- Clarify what PREPEND_PREFIX and ADD_PREFIX_ALIAS configurations do and improve their unit tests
