### PR TITLE
fix(pagination): keep existing behavior for start did, only order wit…

### DIFF
--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -441,7 +441,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             # so we don't need to select distinct for these cases
             if urls_metadata or negate_params:
                 query = query.distinct(IndexRecord.did)
-             
+
             if page is not None:
                 # order by updated date so newly added stuff is
                 # at the end (reduce risk that a new records ends up in a page
@@ -452,7 +452,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 query = query.order_by(IndexRecord.updated_date)
             else:
                 query = query.order_by(IndexRecord.did)
-            
+
             if ids:
                 query = query.filter(IndexRecord.did.in_(ids))
             else:

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -441,15 +441,18 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             # so we don't need to select distinct for these cases
             if urls_metadata or negate_params:
                 query = query.distinct(IndexRecord.did)
-
-            # order by updated date so newly added stuff is
-            # at the end (reduce risk that a new records ends up in a page
-            # earlier on) and allows for some logic to check for newly added records
-            # (e.g. parallelly processing from beginning -> middle and ending -> middle
-            #       and as a final step, checking the "ending"+1 to see if there are
-            #       new records).
-            query = query.order_by(IndexRecord.updated_date)
-
+             
+            if page is not None:
+                # order by updated date so newly added stuff is
+                # at the end (reduce risk that a new records ends up in a page
+                # earlier on) and allows for some logic to check for newly added records
+                # (e.g. parallelly processing from beginning -> middle and ending -> middle
+                #       and as a final step, checking the "ending"+1 to see if there are
+                #       new records).
+                query = query.order_by(IndexRecord.updated_date)
+            else:
+                query = query.order_by(IndexRecord.did)
+            
             if ids:
                 query = query.filter(IndexRecord.did.in_(ids))
             else:


### PR DESCRIPTION
…h new pagination

### New Features


### Breaking Changes


### Bug Fixes

- keep existing behavior when using pagination using start did (instead of new page param), ordering by date causes issues with previous behavior, now only order by date when using new page param

### Improvements


### Dependency updates


### Deployment changes

