### PR TITLE
(PXP-5525): Add blank version of record

### DIFF
--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -295,6 +295,29 @@ def post_index_blank_record():
     return flask.jsonify(ret), 201
 
 
+@blueprint.route("/index/blank/<path:record>", methods=["POST"])
+def add_index_blank_record_version(record):
+    """
+    Create a new blank version of the record with this GUID.
+    Authn/authz fields carry over from the previous version of the record.
+    Only uploader and optionally file_name fields are filled.
+    Returns the GUID of the new blank version and the baseid common to all versions
+    of the record.
+    """
+    uploader = flask.request.get_json().get("uploader")
+    file_name = flask.request.get_json().get("file_name")
+    if not uploader:
+        raise UserError("no uploader specified")
+
+    # authorize done in add_blank_version for both the old and new authz
+    did, baseid, rev = blueprint.index_driver.add_blank_version(
+        record=record, uploader=uploader, file_name=file_name
+    )
+
+    ret = {"did": did, "baseid": baseid, "rev": rev}
+
+    return flask.jsonify(ret), 200
+
 @blueprint.route("/index/blank/<path:record>", methods=["PUT"])
 @authorize
 def put_index_blank_record(record):

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -309,7 +309,7 @@ def add_index_blank_record_version(record):
     if not uploader:
         raise UserError("no uploader specified")
 
-    # authorize done in add_blank_version for both the old and new authz
+    # authorize done in add_blank_version for the existing record's authz
     did, baseid, rev = blueprint.index_driver.add_blank_version(
         record, uploader=uploader, file_name=file_name
     )

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -318,6 +318,7 @@ def add_index_blank_record_version(record):
 
     return flask.jsonify(ret), 201
 
+
 @blueprint.route("/index/blank/<path:record>", methods=["PUT"])
 @authorize
 def put_index_blank_record(record):

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -306,12 +306,13 @@ def add_index_blank_record_version(record):
     """
     uploader = flask.request.get_json().get("uploader")
     file_name = flask.request.get_json().get("file_name")
+    new_did = flask.request.json.get("did")
     if not uploader:
         raise UserError("no uploader specified")
 
     # authorize done in add_blank_version for the existing record's authz
     did, baseid, rev = blueprint.index_driver.add_blank_version(
-        record, uploader=uploader, file_name=file_name
+        record, new_did=new_did, uploader=uploader, file_name=file_name
     )
 
     ret = {"did": did, "baseid": baseid, "rev": rev}

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -311,12 +311,12 @@ def add_index_blank_record_version(record):
 
     # authorize done in add_blank_version for both the old and new authz
     did, baseid, rev = blueprint.index_driver.add_blank_version(
-        record=record, uploader=uploader, file_name=file_name
+        record, uploader=uploader, file_name=file_name
     )
 
     ret = {"did": did, "baseid": baseid, "rev": rev}
 
-    return flask.jsonify(ret), 200
+    return flask.jsonify(ret), 201
 
 @blueprint.route("/index/blank/<path:record>", methods=["PUT"])
 @authorize

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import joinedload, relationship, sessionmaker
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound, FlushError
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from indexd import auth
 from indexd.errors import UserError, AuthError
@@ -1153,7 +1153,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             return record.did, record.baseid, record.rev
 
-    def add_blank_version(self, current_did, new_did=None, file_name=None, uploader=None):
+    def add_blank_version(
+        self, current_did, new_did=None, file_name=None, uploader=None
+    ):
         """
         Add a blank record version given did.
         Authn/authz fields carry over from previous version.
@@ -1218,7 +1220,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 else:
                     baseid = record.baseid
             except MultipleResultsFound:
-                raise MultipleRecordsFoundadd_version("multiple records found")
+                raise MultipleRecordsFound("multiple records found")
 
             query = session.query(IndexRecord)
             records = (

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1169,7 +1169,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             except MultipleResultsFound:
                 raise MultipleRecordsFound("multiple records found")
 
-            auth.authorize("update", [u.resource for u in old_record.authz] + authz)
+            auth.authorize("update", [u.resource for u in old_record.authz])
 
             new_record = IndexRecord()
             did = str(uuid.uuid4())

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1180,11 +1180,8 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             new_record.acl = old_record.acl
             new_record.authz = old_record.authz
 
-            try:
-                session.add(new_record)
-                session.commit()
-            except IntegrityError:
-                raise UserError("{did} already exists".format(did=did), 400)
+            session.add(new_record)
+            session.commit()
 
             return new_record.did, new_record.baseid, new_record.rev
 

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1149,6 +1149,50 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             return record.did, record.baseid, record.rev
 
+    def add_blank_version(
+        self,
+        current_did,
+        file_name=None,
+        uploader=None,
+    ):
+        """
+        Add a blank record version given did.
+        Authn/authz fields carry over from previous version.
+        """
+        with self.session as session:
+            query = session.query(IndexRecord).filter_by(did=current_did)
+
+            try:
+                old_record = query.one()
+            except NoResultFound:
+                raise NoRecordFound("no record found")
+            except MultipleResultsFound:
+                raise MultipleRecordsFound("multiple records found")
+
+            auth.authorize("update", [u.resource for u in old_record.authz] + authz)
+
+            new_record = IndexRecord()
+            did = str(uuid.uuid4())
+            if self.config.get("PREPEND_PREFIX"):
+                did = self.config["DEFAULT_PREFIX"] + did
+
+            new_record.did = did
+            new_record.baseid = old_record.baseid
+            new_record.rev = str(uuid.uuid4())[:8]
+            new_record.file_name = file_name
+            new_record.uploader = uploader
+
+            new_record.acl = old_record.acl
+            new_record.authz = old_record.authz
+
+            try:
+                session.add(new_record)
+                session.commit()
+            except IntegrityError:
+                raise UserError("{did} already exists".format(did=did), 400)
+
+            return new_record.did, new_record.baseid, new_record.rev
+
     def get_all_versions(self, did):
         """
         Get all record versions (in order of creation) given DID

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1149,12 +1149,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             return record.did, record.baseid, record.rev
 
-    def add_blank_version(
-        self,
-        current_did,
-        file_name=None,
-        uploader=None,
-    ):
+    def add_blank_version(self, current_did, file_name=None, uploader=None):
         """
         Add a blank record version given did.
         Authn/authz fields carry over from previous version.

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -236,7 +236,7 @@ paths:
           schema:
             $ref: '#/definitions/InputBlankInfo'
       responses:
-        '200':
+        '201':
           description: successful operation
           schema:
             $ref: '#/definitions/OutputRef'
@@ -268,7 +268,7 @@ paths:
           schema:
             $ref: '#/definitions/InputBlankVersionInfo'
       responses:
-        '200':
+        '201':
           description: successful operation
           schema:
             $ref: '#/definitions/OutputRef'
@@ -1400,18 +1400,6 @@ definitions:
       rev:
         type: string
         pattern: '^[0-9a-f]{8}$'
-  OutputRefWithURL:
-    type: object
-    properties:
-      did:
-        $ref: "#/definitions/DID"
-      baseid:
-        $ref: "#/definitions/UUID"
-      rev:
-        type: string
-        pattern: '^[0-9a-f]{8}$'
-      url:
-        type: string
   AliasInputInfo:
     type: object
     required:

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -266,7 +266,7 @@ paths:
           description: Metadata object that needs to be added to the store
           required: true
           schema:
-            $ref: '#/definitions/InputBlankInfo'
+            $ref: '#/definitions/InputBlankVersionInfo'
       responses:
         '200':
           description: successful operation
@@ -274,6 +274,8 @@ paths:
             $ref: '#/definitions/OutputRef'
         '400':
           description: Invalid status value
+        '404':
+          description: GUID does not exist
       security:
         - basic_auth: []
     put:
@@ -1337,6 +1339,18 @@ definitions:
       file_name:
         type: string
         description: name of the uploaded file
+  InputBlankVersionInfo:
+    type: object
+    properties:
+      uploader:
+        type: string
+        description: user who uploaded this file
+      file_name:
+        type: string
+        description: optional; name of the uploaded file
+      did:
+        type: string
+        description: optional; specify the GUID of the new blank version that is created.
   UpdateInputInfo:
     type: object
     properties:

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -245,6 +245,37 @@ paths:
       security:
         - basic_auth: []
   '/index/blank/{GUID}':
+    post:
+      tags:
+        - index
+      summary: Create a new, blank version for the document associated to the provided uuid.
+      description: Creates a new blank version of a record with the provided GUID. Returns the GUID of the new version of the record and the baseid common to all versions of the record. Authorization (acl/authz fields) carry over from the original record to the new blank version. No other metadata (md5sum, etc) carries over from the original record to the new blank version.
+      operationId: addNewBlankVersion
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: GUID
+          in: path
+          description: the uuid associated to the record needed to have new version
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Metadata object that needs to be added to the store
+          required: true
+          schema:
+            $ref: '#/definitions/InputBlankInfo'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/OutputRef'
+        '400':
+          description: Invalid status value
+      security:
+        - basic_auth: []
     put:
       tags:
         - index
@@ -898,7 +929,7 @@ paths:
         - DOS
   '/ga4gh/drs/v1/objects':
     get:
-      summary: List all DrsObject. 
+      summary: List all DrsObject.
       description: 'Url field here contains their location and not the presigned url.'
       operationId: ListDrsObject
       responses:
@@ -966,13 +997,13 @@ paths:
           type: boolean
           default: false
           description: >-
-            NOT IMPLEMENTED YET. 
-            
+            NOT IMPLEMENTED YET.
+
             If false and the object_id refers to a bundle, then the ContentsObject array
             contains only those objects directly contained in the bundle. That is, if the
             bundle contains other bundles, those other bundles are not recursively
             included in the result.
-            
+
             If true and the object_id refers to a bundle, then the entire set of objects
             in the bundle is expanded. That is, if the bundle contains aother bundles,
             then those other bundles are recursively expanded and included in the result.
@@ -1043,7 +1074,7 @@ paths:
       tags:
         - DRS
       x-swagger-router-controller: ga4gh.drs.server
-    
+
   '/bulk/documents':
     post:
       tags:
@@ -1067,7 +1098,7 @@ paths:
         '400':
           description: Invalid status value
       security: []
-  
+
   '/_query/urls/q':
     get:
       tags:
@@ -1350,6 +1381,18 @@ definitions:
       rev:
         type: string
         pattern: '^[0-9a-f]{8}$'
+  OutputRefWithURL:
+    type: object
+    properties:
+      did:
+        $ref: "#/definitions/DID"
+      baseid:
+        $ref: "#/definitions/UUID"
+      rev:
+        type: string
+        pattern: '^[0-9a-f]{8}$'
+      url:
+        type: string
   AliasInputInfo:
     type: object
     required:
@@ -1785,7 +1828,7 @@ definitions:
         format: date-time
         description: |-
           Timestamp of content creation in RFC3339.
-          (This is the creation time of the underlying content, not of the JSON object.) 
+          (This is the creation time of the underlying content, not of the JSON object.)
       updated_time:
         type: string
         format: date-time
@@ -1904,7 +1947,7 @@ definitions:
           A name declared by the bundle author that must be
           used when materialising this object,
           overriding any name directly associated with the object itself.
-          The name must be unique with the containing bundle. 
+          The name must be unique with the containing bundle.
           This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
       id:
         type: string
@@ -1931,7 +1974,7 @@ definitions:
         items:
           example:
             {}
-        
+
     required:
       - name
   Error:
@@ -1944,15 +1987,15 @@ definitions:
         description: A detailed error message.
       status_code:
         type: integer
-        description: The integer representing the HTTP status code (e.g. 200, 404).  
+        description: The integer representing the HTTP status code (e.g. 200, 404).
   ListDrsObject:
     type: object
     properties:
-      drs_objects: 
+      drs_objects:
         type: array
         items:
           $ref: '#/definitions/DrsObject'
-          
+
   ListRecords:
     type: object
     properties:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1311,6 +1311,17 @@ def test_index_create_with_version(client, user):
     rec = res.json
     assert rec["version"] == data["version"]
 
+def test_create_blank_record_with_baseid(client, user):
+    doc = {"uploader": "uploader_123", "baseid": "baseid_123"}
+
+    res = client.post("/index/blank/", json=doc, headers=user)
+    assert res.status_code == 201
+    rec = res.json
+    assert rec["did"]
+    res = client.get("/index/?baseid=" + doc["baseid"])
+    assert res.status_code == 200
+    rec = res.json
+    assert_blank(rec)
 
 def test_index_create_with_uploader(client, user):
     data = get_doc()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -754,6 +754,7 @@ def test_create_blank_version_specify_guid_already_exists(client, user):
         res.status_code == 400
     ), "Request should have failed with 400 user error: {}".format(res.json)
 
+
 def test_create_blank_version_no_existing_record(client, user):
     """
     Test that attempts to create a blank version of a nonexisting GUID
@@ -768,6 +769,7 @@ def test_create_blank_version_no_existing_record(client, user):
     assert (
         res.status_code == 404
     ), "Expected to fail to create new blank version, instead got {}".format(res.json)
+
 
 def test_create_blank_version_blank_record(client, user):
     """
@@ -821,6 +823,7 @@ def test_create_blank_version_blank_record(client, user):
     ]
     for field in blank_fields:
         assert not blank_doc[field]
+
 
 def test_fill_size_n_hash_for_blank_record(client, user):
     """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -575,6 +575,7 @@ def test_create_blank_record_with_file_name(client, user):
     # test that record is blank
     assert_blank(rec)
 
+
 def test_create_blank_version(client, user):
     """
     Test that we can create a new, blank version of a record
@@ -593,10 +594,14 @@ def test_create_blank_version(client, user):
     doc["authz"] = mock_authz
     doc["baseid"] = mock_baseid
     res = client.post("/index/", json=doc, headers=user)
-    assert res.status_code == 200, "Failed to add original doc to index: {}".format(res.json)
+    assert res.status_code == 200, "Failed to add original doc to index: {}".format(
+        res.json
+    )
     original_doc_guid = res.json["did"]
     res = client.get("/index/{}".format(original_doc_guid))
-    assert res.status_code == 200, "Failed to find original doc in index: {}".format(res.json)
+    assert res.status_code == 200, "Failed to find original doc in index: {}".format(
+        res.json
+    )
     original_doc = res.json
     assert original_doc["acl"] == mock_acl
     assert original_doc["authz"] == mock_authz
@@ -606,7 +611,9 @@ def test_create_blank_version(client, user):
     doc = {"uploader": "uploader_123", "file_name": "test_file"}
     url = "/index/blank/{}".format(original_doc["did"])
     res = client.post(url, json=doc, headers=user)
-    assert res.status_code == 201, "Failed to make new blank version: {}".format(res.json)
+    assert res.status_code == 201, "Failed to make new blank version: {}".format(
+        res.json
+    )
     blank_doc_guid = res.json["did"]
 
     # Confirm that the new blank record is in the index
@@ -638,6 +645,7 @@ def test_create_blank_version(client, user):
     ]
     for field in blank_fields:
         assert not blank_doc[field]
+
 
 def test_fill_size_n_hash_for_blank_record(client, user):
     """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1295,24 +1295,6 @@ def test_index_create_with_version(client, user):
     rec = res.json
     assert rec["version"] == data["version"]
 
-
-# NOTE @mpingram this test is buggy -- POST /index/blank does
-# not support specifying the baseid as far as I know, and this test
-# only passes because it does not compare the original baseid with
-# the baseid returned from POST /index/blank.
-def test_create_blank_record_with_baseid(client, user):
-    doc = {"uploader": "uploader_123", "baseid": "baseid_123"}
-
-    res = client.post("/index/blank/", json=doc, headers=user)
-    assert res.status_code == 201
-    rec = res.json
-    assert rec["did"]
-    res = client.get("/index/?baseid=" + doc["baseid"])
-    assert res.status_code == 200
-    rec = res.json
-    assert_blank(rec)
-
-
 def test_index_create_with_uploader(client, user):
     data = get_doc()
     data["uploader"] = "uploader_123"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -647,6 +647,113 @@ def test_create_blank_version(client, user):
         assert not blank_doc[field]
 
 
+def test_create_blank_version_specify_did(client, user):
+    """
+    Test that we can specify the new GUID of a new, blank version of a record
+    with POST /index/blank/{GUID}.
+    """
+    # SETUP
+    # ----------
+    # Add an original record to the index
+    doc = get_doc()
+    mock_acl = ["acl_A", "acl_B"]
+    mock_authz = ["fake/authz/A", "fake/authz/B"]
+    mock_baseid = "00000000-0000-0000-0000-000000000000"
+    doc["acl"] = mock_acl
+    doc["authz"] = mock_authz
+    doc["baseid"] = mock_baseid
+    res = client.post("/index/", json=doc, headers=user)
+    assert res.status_code == 200, "Failed to add original doc to index: {}".format(
+        res.json
+    )
+    original_doc_guid = res.json["did"]
+    res = client.get("/index/{}".format(original_doc_guid))
+    assert res.status_code == 200, "Failed to find original doc in index: {}".format(
+        res.json
+    )
+    original_doc = res.json
+    assert original_doc["acl"] == mock_acl
+    assert original_doc["authz"] == mock_authz
+    assert original_doc["baseid"] == mock_baseid
+
+    # Make a new blank version of the original record, specifying the guid
+    specified_guid = "11111111-1111-1111-1111-111111111111"
+    doc = {"uploader": "uploader_123", "file_name": "test_file", "did": specified_guid}
+    url = "/index/blank/{}".format(original_doc["did"])
+    res = client.post(url, json=doc, headers=user)
+    assert res.status_code == 201, "Failed to make new blank version: {}".format(
+        res.json
+    )
+    blank_doc_guid = res.json["did"]
+
+    # Confirm that the new blank record is in the index
+    res = client.get("/index/{}".format(blank_doc_guid))
+    assert res.status_code == 200, "Failed to find blank record: {}".format(res.json)
+    blank_doc = res.json
+    # -----------
+
+    # Expect the new version's guid to be the guid we specified
+    assert blank_doc_guid == specified_guid
+
+
+def test_create_blank_version_specify_guid_already_exists(client, user):
+    """
+    Test that if we try to specify the GUID of a new blank version, but the
+    new GUID we specified already exists in the index, the operation fails with 400.
+    """
+    # SETUP
+    # ----------
+    # Add an original record to the index
+    doc = get_doc()
+    mock_acl = ["acl_A", "acl_B"]
+    mock_authz = ["fake/authz/A", "fake/authz/B"]
+    mock_baseid = "00000000-0000-0000-0000-000000000000"
+    doc["acl"] = mock_acl
+    doc["authz"] = mock_authz
+    doc["baseid"] = mock_baseid
+    res = client.post("/index/", json=doc, headers=user)
+    assert res.status_code == 200, "Failed to add original doc to index: {}".format(
+        res.json
+    )
+    original_doc_guid = res.json["did"]
+    res = client.get("/index/{}".format(original_doc_guid))
+    assert res.status_code == 200, "Failed to find original doc in index: {}".format(
+        res.json
+    )
+    original_doc = res.json
+    assert original_doc["acl"] == mock_acl
+    assert original_doc["authz"] == mock_authz
+    assert original_doc["baseid"] == mock_baseid
+
+    # Add another, unrelated record to the index
+    res = client.post("/index/", json=get_doc(), headers=user)
+    assert res.status_code == 200, "Failed to add original doc to index: {}".format(
+        res.json
+    )
+    preexisting_guid = res.json["did"]
+    # -----------
+
+    # Attempt to create new blank version of doc, specifying the new guid to be
+    # a guid that already exists in the index. Expect the operation to fail with 400.
+    specified_guid = preexisting_guid
+    doc = {"uploader": "uploader_123", "file_name": "test_file", "did": specified_guid}
+    url = "/index/blank/{}".format(original_doc["did"])
+    res = client.post(url, json=doc, headers=user)
+    assert (
+        res.status_code == 400
+    ), "Request should have failed with 400 user error: {}".format(res.json)
+
+    # Attempt to create new blank version of doc, specifying the new guid to be
+    # the guid of the original record we're making a new blank version of.
+    # Expect the operation to fail with 400.
+    specified_guid = original_doc_guid
+    doc = {"uploader": "uploader_123", "file_name": "test_file", "did": specified_guid}
+    url = "/index/blank/{}".format(original_doc["did"])
+    res = client.post(url, json=doc, headers=user)
+    assert (
+        res.status_code == 400
+    ), "Request should have failed with 400 user error: {}".format(res.json)
+
 def test_create_blank_version_no_existing_record(client, user):
     """
     Test that attempts to create a blank version of a nonexisting GUID

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1311,6 +1311,7 @@ def test_index_create_with_version(client, user):
     rec = res.json
     assert rec["version"] == data["version"]
 
+
 def test_create_blank_record_with_baseid(client, user):
     doc = {"uploader": "uploader_123", "baseid": "baseid_123"}
 
@@ -1322,6 +1323,7 @@ def test_create_blank_record_with_baseid(client, user):
     assert res.status_code == 200
     rec = res.json
     assert_blank(rec)
+
 
 def test_index_create_with_uploader(client, user):
     data = get_doc()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -646,6 +646,18 @@ def test_create_blank_version(client, user):
     for field in blank_fields:
         assert not blank_doc[field]
 
+def test_create_blank_version_no_existing_record(client, user):
+    """
+    Test that attempts to create a blank version of a nonexisting GUID
+    should fail with 404.
+    """
+    nonexistant_did = "00000000-0000-0000-0000-000000000000"
+
+    # Make a new blank version of the original record
+    doc = {"uploader": "uploader_123", "file_name": "test_file"}
+    url = "/index/blank/{}".format(nonexistant_did)
+    res = client.post(url, json=doc, headers=user)
+    assert res.status_code == 404, "Expected to fail to create new blank version, instead got {}".format(res.json)
 
 def test_fill_size_n_hash_for_blank_record(client, user):
     """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -646,6 +646,7 @@ def test_create_blank_version(client, user):
     for field in blank_fields:
         assert not blank_doc[field]
 
+
 def test_create_blank_version_no_existing_record(client, user):
     """
     Test that attempts to create a blank version of a nonexisting GUID
@@ -657,7 +658,10 @@ def test_create_blank_version_no_existing_record(client, user):
     doc = {"uploader": "uploader_123", "file_name": "test_file"}
     url = "/index/blank/{}".format(nonexistant_did)
     res = client.post(url, json=doc, headers=user)
-    assert res.status_code == 404, "Expected to fail to create new blank version, instead got {}".format(res.json)
+    assert (
+        res.status_code == 404
+    ), "Expected to fail to create new blank version, instead got {}".format(res.json)
+
 
 def test_fill_size_n_hash_for_blank_record(client, user):
     """
@@ -1306,6 +1310,7 @@ def test_index_create_with_version(client, user):
     assert res.status_code == 200
     rec = res.json
     assert rec["version"] == data["version"]
+
 
 def test_index_create_with_uploader(client, user):
     data = get_doc()


### PR DESCRIPTION
Jira Ticket: [PXP-5525](https://ctds-planx.atlassian.net/browse/PXP-5525)

Adds support for the POST `/index/blank/{{GUID}}` endpoint, which allows creation of a new blank version of an existing record.

### New Features
- Add support for creating a new, blank version of a record through the POST `/index/blank/{{GUID}}` endpoint.


