### PR TITLE
Prepend prefix to new versions

### DIFF
--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1111,7 +1111,11 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             baseid = record.baseid
             record = IndexRecord()
-            did = new_did or str(uuid.uuid4())
+            did = new_did
+            if not did:
+                did = str(uuid.uuid4())
+                if self.config.get("PREPEND_PREFIX"):
+                    did = self.config["DEFAULT_PREFIX"] + did
 
             record.did = did
             record.baseid = baseid

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "doiclient",
         "dosclient",
         "hsclient",
-        "authutils",
+        "authutils==4.0.0",
         "gen3rbac",
     ],
     dependency_links=[

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1029,17 +1029,29 @@ def test_index_prepend_prefix(client, user):
         "PREPEND_PREFIX": True
     }
     """
+    # create a new record, check the GUID has the prefix
     data = get_doc()
-
     res_1 = client.post("/index/", json=data, headers=user)
-    assert res_1.status_code == 200
+    assert res_1.status_code == 200, res_1.json
     rec_1 = res_1.json
     res_2 = client.get("/index/" + rec_1["did"])
-    assert res_2.status_code == 200
+    assert res_2.status_code == 200, res_2.json
     rec_2 = res_2.json
-
     assert rec_1["did"] == rec_2["did"]
     assert rec_2["did"].startswith("testprefix:")
+
+    # create a new version, check the GUID has the prefix
+    dataNew = {
+        "form": "object",
+        "size": 244,
+        "urls": ["s3://endpointurl/bucket2/key"],
+        "hashes": {"md5": "8b9942cf415384b27cadf1f4d2d981f5"},
+    }
+    res_3 = client.post("/index/" + rec_1["did"], json=dataNew, headers=user)
+    assert res_3.status_code == 200, res_3.json
+    rec_3 = res_3.json
+    assert rec_3["baseid"] == rec_1["baseid"]
+    assert rec_3["did"].startswith("testprefix:")
 
 
 def test_index_get_with_baseid(client, user):


### PR DESCRIPTION
because of the unpinned authutils, version “5.0.0b1" was being installed, which tried to install cdiserrors version "1.0.0b1" and errored

### Improvements
- Prepend the configured prefix to new versions' GUIDs, unless a GUID has been provided by the user

### Dependency updates
- Pin authutils==4.0.0 in setup.py
