### PR TITLE
gen3rbac==0.1.2 -> gen3authz==0.4.0

### DIFF
--- a/indexd/auth/drivers/alchemy.py
+++ b/indexd/auth/drivers/alchemy.py
@@ -5,7 +5,7 @@ import hashlib
 from contextlib import contextmanager
 
 from authutils.token import get_jwt_token
-from rbac.client.arborist.client import ArboristClient
+from gen3authz.client.arborist.client import ArboristClient
 from sqlalchemy import String
 from sqlalchemy import Column
 from sqlalchemy.orm import sessionmaker

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient
 git+https://github.com/uc-cdis/dosclient.git@1.1.0#egg=dosclient
 git+https://github.com/uc-cdis/hsclient.git@1.0.0#egg=hsclient
 authutils==4.0.0
-gen3rbac==0.1.2
+gen3authz==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "dosclient",
         "hsclient",
         "authutils==4.0.0",
-        "gen3rbac",
+        "gen3authz>=0.4.0,<0.5.0",
     ],
     dependency_links=[
         "git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging",


### PR DESCRIPTION
fix error:
```
  File "/usr/local/lib/python3.6/site-packages/rbac/client/arborist/client.py", line 152, in auth_request
    msg = "request to arborist failed: {}".format(response.json())
TypeError: 'dict' object is not callable
```

### Dependency updates
- update gen3authz to latest version
