### PR TITLE
(PXP-1745): Update acl/authz across all versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('cdis-jenkins-lib@master') _
+@Library('cdis-jenkins-lib@chore/debug_wait_for_quay_build') _
 
 testPipeline { 
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('cdis-jenkins-lib@chore/debug_wait_for_quay_build') _
+@Library('cdis-jenkins-lib@master') _
 
 testPipeline { 
 }

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -504,7 +504,7 @@ def get_all_index_record_versions(record):
     return flask.jsonify(ret), 200
 
 @blueprint.route("/index/<path:record>/versions", methods=["PUT"])
-def get_all_index_record_versions(record):
+def update_all_index_record_versions(record):
     """
     Update metadata for all record versions.
     NOTE currently the only fields that can be updated for all versions are

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -503,6 +503,7 @@ def get_all_index_record_versions(record):
 
     return flask.jsonify(ret), 200
 
+
 @blueprint.route("/index/<path:record>/versions", methods=["PUT"])
 def update_all_index_record_versions(record):
     """
@@ -520,11 +521,7 @@ def update_all_index_record_versions(record):
     acl = request_json.get("acl", None)
     authz = request_json.get("authz", None)
     # authorization and error handling done in driver
-    ret = blueprint.index_driver.update_all_versions(
-        record,
-        acl=acl,
-        authz=authz,
-    )
+    ret = blueprint.index_driver.update_all_versions(record, acl=acl, authz=authz)
 
     return flask.jsonify(ret), 200
 

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -14,6 +14,7 @@ from indexd.errors import UserError
 from .schema import PUT_RECORD_SCHEMA
 from .schema import POST_RECORD_SCHEMA
 from .schema import RECORD_ALIAS_SCHEMA
+from .schema import UPDATE_ALL_VERSIONS_SCHEMA
 
 from .errors import NoRecordFound
 from .errors import MultipleRecordsFound
@@ -499,6 +500,31 @@ def get_all_index_record_versions(record):
     Get all record versions
     """
     ret = blueprint.index_driver.get_all_versions(record)
+
+    return flask.jsonify(ret), 200
+
+@blueprint.route("/index/<path:record>/versions", methods=["PUT"])
+def get_all_index_record_versions(record):
+    """
+    Update metadata for all record versions.
+    NOTE currently the only fields that can be updated for all versions are
+    (`authz`, `acl`).
+    """
+    request_json = flask.request.get_json(force=True)
+    try:
+        jsonschema.validate(request_json, UPDATE_ALL_VERSIONS_SCHEMA)
+    except jsonschema.ValidationError as err:
+        logger.warn(f"Bad request body:\n{err}")
+        raise UserError(err)
+
+    acl = request_json.get("acl", None)
+    authz = request_json.get("authz", None)
+    # authorization and error handling done in driver
+    ret = blueprint.index_driver.update_all_versions(
+        record,
+        acl=acl,
+        authz=authz,
+    )
 
     return flask.jsonify(ret), 200
 

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -518,8 +518,8 @@ def update_all_index_record_versions(record):
         logger.warn(f"Bad request body:\n{err}")
         raise UserError(err)
 
-    acl = request_json.get("acl", None)
-    authz = request_json.get("authz", None)
+    acl = request_json.get("acl")
+    authz = request_json.get("authz")
     # authorization and error handling done in driver
     ret = blueprint.index_driver.update_all_versions(record, acl=acl, authz=authz)
 

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1249,10 +1249,6 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             except MultipleResultsFound:
                 raise MultipleRecordsFound("multiple records found")
 
-            # FIXME need to support acl field here?
-            auth.authorize("update", [u.resource for u in old_record.authz])
-
-            # NOTE does user need to be authorized for just this record, or authorized for all versions?
             # Find all versions
             query = session.query(IndexRecord)
             records = (
@@ -1260,6 +1256,10 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 .order_by(IndexRecord.created_date.asc())
                 .all()
             )
+
+            # User requires update permissions for all versions of the record
+            all_versions_authz = {r.authz for r in records}
+            auth.authorize("update", [u.resource for u in all_versions_authz])
 
             ret = []
             # Update fields for all versions

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1263,11 +1263,12 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             )
 
             # User requires update permissions for all versions of the record
-            all_resources = []
-            for rec in records:
-                for resource in rec.authz:
-                    all_resources.append(resource)
-            auth.authorize("update", all_resources)
+            all_resources = {
+                resource
+                for rec in records
+                for resource in rec.authz
+            }
+            auth.authorize("update", list(all_resources))
 
             ret = []
             # Update fields for all versions

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1273,7 +1273,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             # Update fields for all versions
             for record in records:
                 if acl:
-                    record.acl = [IndexRecordACE(did=record.did, ace=ace) for ace in set(acl)]
+                    record.acl = [
+                        IndexRecordACE(did=record.did, ace=ace) for ace in set(acl)
+                    ]
                 if authz:
                     record.authz = [
                         IndexRecordAuthz(did=record.did, resource=resource)
@@ -1285,7 +1287,6 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 )
             session.commit()
             return ret
-
 
     def get_latest_version(self, did, has_version=None):
         """

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1263,11 +1263,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             )
 
             # User requires update permissions for all versions of the record
-            all_resources = {
-                resource
-                for rec in records
-                for resource in rec.authz
-            }
+            all_resources = {resource for rec in records for resource in rec.authz}
             auth.authorize("update", list(all_resources))
 
             ret = []

--- a/indexd/index/schema.py
+++ b/indexd/index/schema.py
@@ -106,11 +106,11 @@ UPDATE_ALL_VERSIONS_SCHEMA = {
     "properties": {
       "acl": {
         "type": "array",
-        "items"{ "type": "string" },
+        "items": { "type": "string" },
         },
       "authz": {
         "type": "array",
-        "items"{ "type": "string" },
+        "items":{ "type": "string" },
         },
     },
 }

--- a/indexd/index/schema.py
+++ b/indexd/index/schema.py
@@ -104,13 +104,7 @@ UPDATE_ALL_VERSIONS_SCHEMA = {
     "additionalProperties": False,
     "description": "The metadata to update for all versions of the record. Only some fields can be updated in this way.",
     "properties": {
-      "acl": {
-        "type": "array",
-        "items": { "type": "string" },
-        },
-      "authz": {
-        "type": "array",
-        "items":{ "type": "string" },
-        },
+        "acl": {"type": "array", "items": {"type": "string"}},
+        "authz": {"type": "array", "items": {"type": "string"}},
     },
 }

--- a/indexd/index/schema.py
+++ b/indexd/index/schema.py
@@ -97,3 +97,20 @@ RECORD_ALIAS_SCHEMA = {
         }
     },
 }
+
+UPDATE_ALL_VERSIONS_SCHEMA = {
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "additionalProperties": False,
+    "description": "The metadata to update for all versions of the record. Only some fields can be updated in this way.",
+    "properties": {
+      "acl": {
+        "type": "array",
+        "items"{ "type": "string" },
+        },
+      "authz": {
+        "type": "array",
+        "items"{ "type": "string" },
+        },
+    },
+}

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -628,6 +628,39 @@ paths:
         '400':
           description: Invalid status value
       security: []
+    put:
+      tags:
+        - index
+      summary: Update metadata for all versions of this record. Only some metadata fields can be updated in this way.
+      operationId: updateAllVersions
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: GUID
+          in: path
+          description: entry id
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: The metadata to update for all versions of the record. Only some fields can be updated in this way.
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateAllVersionsInputInfo'
+      responses:
+        '200':
+          description: Successful operation. Returns the GUIDs of the records that were updated.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/OutputRef'
+        '400':
+          description: The metadata to update is invalid.
+        '404':
+          description: GUID not found.
+      security: []
   '/alias/':
     get:
       deprecated: true
@@ -1387,6 +1420,17 @@ definitions:
       hashes:
         $ref: '#/definitions/HashInfo'
       urls:
+        type: array
+        items:
+          type: string
+  UpdateAllVersionsInputInfo:
+    type: object
+    properties:
+      acl:
+        type: array
+        items:
+          type: string
+      authz:
         type: array
         items:
           type: string

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -615,9 +615,9 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: GUID
+        - name: GUID / baseid
           in: path
-          description: entry id
+          description: GUID of any record version, or the baseid common to all versions
           required: true
           type: string
       responses:
@@ -638,9 +638,9 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: GUID
+        - name: GUID / baseid
           in: path
-          description: entry id
+          description: GUID of any record version, or the baseid common to all versions
           required: true
           type: string
         - in: body

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -658,6 +658,8 @@ paths:
               $ref: '#/definitions/OutputRef'
         '400':
           description: The metadata to update is invalid.
+        '403':
+          description: The requester is not authorized to perform this action. The requester must have the Update permission on all versions of the record.
         '404':
           description: GUID not found.
       security: []

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -615,7 +615,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: GUID / baseid
+        - name: GUID
           in: path
           description: GUID of any record version, or the baseid common to all versions
           required: true
@@ -638,7 +638,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: GUID / baseid
+        - name: GUID
           in: path
           description: GUID of any record version, or the baseid common to all versions
           required: true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,6 @@ pytest==3.0.6
 pytest-cov==2.5.1
 pytest-flask==0.8.1
 PyYAML==5.1
-swagger_spec_validator
+swagger_spec_validator==2.6.0
 responses
 -e git+https://github.com/uc-cdis/cdisutils-test.git@1.0.0#egg=cdisutilstest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ def use_mock_authz(mock_authz_permissions):
     The username is read from the HTTP Basic Auth header of incoming requests.
     """
     orig = auth.authorize
+
     def mock_authorize(method, resources):
         username = request.authorization.username
         user_permissions = mock_authz_permissions.get(username, None)
@@ -72,6 +73,7 @@ def use_mock_authz(mock_authz_permissions):
         for resource in resources:
             if resource not in user_permissions.get(method, []):
                 raise AuthError("Permission denied.")
+
     auth.authorize = mock_authorize
     yield
     auth.authorize = orig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from indexd import get_app
 import base64
 import pytest
+from flask import request
 
 import importlib
 
@@ -9,6 +10,7 @@ from cdisutilstest.code.conftest import indexd_server, indexd_client  # noqa
 from cdisutilstest.code.indexd_fixture import clear_database
 
 from indexd import auth
+from indexd.auth.errors import AuthError
 from tests import default_test_settings
 
 
@@ -42,5 +44,34 @@ def user(app):
 def skip_authz():
     orig = auth.authorize
     auth.authorize = lambda *x: x
+    yield
+    auth.authorize = orig
+
+
+@pytest.fixture
+def use_mock_authz(mock_authz_permissions):
+    """
+    Fixture for enabling mocking of authz permission system. Takes as a parameter
+    an authz configuration dict in the form of:
+    ```
+    {
+        $username: {
+            $method: [$resource]
+        }
+    }
+    ```
+    This configures which usernames have which permissions.
+    The username is read from the HTTP Basic Auth header of incoming requests.
+    """
+    orig = auth.authorize
+    def mock_authorize(method, resources):
+        username = request.authorization.username
+        user_permissions = mock_authz_permissions.get(username, None)
+        if not user_permissions:
+            raise AuthError("Permission denied.")
+        for resource in resources:
+            if resource not in user_permissions.get(method, []):
+                raise AuthError("Permission denied.")
+    auth.authorize = mock_authorize
     yield
     auth.authorize = orig

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import json
+import base64
 
 import pytest
 
@@ -1775,6 +1776,7 @@ def test_get_all_versions(client, user):
     for i, record in recs1.items():
         assert record["did"] == dids[int(i)], "record id does not match"
 
+
 def test_update_all_versions(client, user):
     dids = []
     mock_acl_A = ["mock_acl_A1", "mock_acl_A2"]
@@ -1804,11 +1806,10 @@ def test_update_all_versions(client, user):
     # ----------
 
     # Update all versions
-    update_data = {
-        "acl": mock_acl_B,
-        "authz": mock_authz_B
-    }
-    res = client.put("/index/{}/versions".format(rec1["did"]), json=update_data, headers=user)
+    update_data = {"acl": mock_acl_B, "authz": mock_authz_B}
+    res = client.put(
+        "/index/{}/versions".format(rec1["did"]), json=update_data, headers=user
+    )
     assert res.status_code == 200, "Failed to update all version: {}".format(res.json)
     # Expect the GUIDs of all updated versions to be returned by the request,
     # in order of version creation
@@ -1817,10 +1818,163 @@ def test_update_all_versions(client, user):
     # Expect all versions to have the new acl/authz
     res = client.get("/index/{}/versions".format(rec1["did"]))
     assert res.status_code == 200, "Failed to get all versions"
-    print("TEST_PRINT: {}".format(res.json))
     for _, version in res.json.items():
         assert version["acl"] == mock_acl_B
         assert version["authz"] == mock_authz_B
+
+
+def test_update_all_versions_using_baseid(client, user):
+    mock_acl_A = ["mock_acl_A1", "mock_acl_A2"]
+    mock_acl_B = ["mock_acl_B1", "mock_acl_B2"]
+    mock_authz_A = ["mock_authz_A1", "mock_authz_A2"]
+    mock_authz_B = ["mock_authz_B1", "mock_authz_B2"]
+
+    # SETUP
+    # -------
+    # create 1st version
+    data = get_doc(has_metadata=False, has_baseid=False)
+    data["acl"] = mock_acl_A
+    data["authz"] = mock_authz_A
+
+    res = client.post("/index/", json=data, headers=user)
+    assert res.status_code == 200
+    rec1 = res.json
+    assert rec1["did"]
+    baseid = rec1["baseid"]
+
+    # create 2nd version
+    res = client.post("/index/" + rec1["did"], json=data, headers=user)
+    assert res.status_code == 200
+    rec2 = res.json
+    assert rec2["baseid"] == baseid
+    # ----------
+
+    # Update all versions
+    update_data = {"acl": mock_acl_B, "authz": mock_authz_B}
+    res = client.put(
+        "/index/{}/versions".format(baseid), json=update_data, headers=user
+    )
+    assert res.status_code == 200, "Failed to update all version: {}".format(res.json)
+
+    # Expect all versions to have the new acl/authz
+    res = client.get("/index/{}/versions".format(rec1["did"]))
+    assert res.status_code == 200, "Failed to get all versions"
+    for _, version in res.json.items():
+        assert version["acl"] == mock_acl_B
+        assert version["authz"] == mock_authz_B
+
+
+def test_update_all_versions_guid_not_found(client, user):
+    bad_guid = "00000000-0000-0000-0000-000000000000"
+
+    update_data = {"acl": ["mock_acl"], "authz": ["mock_authz"]}
+    res = client.put(
+        "/index/{}/versions".format(bad_guid), json=update_data, headers=user
+    )
+    # Expect the operation to fail with 404 -- Guid not found
+    assert (
+        res.status_code == 404
+    ), "Expected update operation to fail with 404: {}".format(res.json)
+
+
+def test_update_all_versions_fail_on_bad_metadata(client, user):
+    """
+    When making an update request, endpoint should return 400 (User error) if
+    the metadata to update contains any fields that cannot be updated across all versions.
+    Currently the only allowed fields are ('acl', 'authz').
+    """
+    mock_acl_A = ["mock_acl_A1", "mock_acl_A2"]
+    mock_acl_B = ["mock_acl_B1", "mock_acl_B2"]
+    mock_authz_A = ["mock_authz_A1", "mock_authz_A2"]
+    mock_authz_B = ["mock_authz_B1", "mock_authz_B2"]
+
+    # SETUP
+    # -------
+    # create 1st version
+    data = get_doc(has_metadata=False, has_baseid=False)
+    data["acl"] = mock_acl_A
+    data["authz"] = mock_authz_A
+
+    res = client.post("/index/", json=data, headers=user)
+    assert res.status_code == 200
+    rec1 = res.json
+    assert rec1["did"]
+    baseid = rec1["baseid"]
+
+    # create 2nd version
+    res = client.post("/index/" + rec1["did"], json=data, headers=user)
+    assert res.status_code == 200
+    rec2 = res.json
+    assert rec2["baseid"] == baseid
+    # ----------
+
+    # Update all versions
+    update_data = {"urls": ["url_A"], "acl": mock_acl_B, "authz": mock_authz_B}
+    res = client.put(
+        "/index/{}/versions".format(baseid), json=update_data, headers=user
+    )
+    # Expect the operation to fail with 400
+    assert (
+        res.status_code == 400
+    ), "Expected update operation to fail with 400: {}".format(res.json)
+
+    # Expect all versions to retain the old acl/authz
+    res = client.get("/index/{}/versions".format(rec1["did"]))
+    assert res.status_code == 200, "Failed to get all versions"
+    for _, version in res.json.items():
+        assert version["acl"] == mock_acl_A
+        assert version["authz"] == mock_authz_A
+
+
+@pytest.mark.parametrize(
+    "mock_authz_permissions",
+    [
+        {
+            "test": {
+                "create": ["resource_A", "resource_B"],
+                "update": ["resource_A", "resource_B"],
+            },
+            "test_user": {"update": ["resource_B"]},
+        }
+    ],
+)
+def test_update_all_versions_fail_on_missing_permissions(client, user, use_mock_authz):
+    """
+    If user does not have the 'update' permission on any record, request should
+    fail with 403.
+    """
+    # SETUP
+    # -------
+    admin_user = user
+    test_user = {
+        "Authorization": (
+            "Basic " + base64.b64encode(b"test_user:test").decode("ascii")
+        ),
+        "Content-Type": "application/json",
+    }
+
+    # Base document is inaccessible to test user.
+    doc_1 = get_doc(has_metadata=False, has_baseid=False)
+    doc_1["authz"] = ["resource_A"]
+    res = client.post("/index/", json=doc_1, headers=admin_user)
+    assert res.status_code == 200, res.json
+
+    # Second version is accessible to test user.
+    doc_2 = get_doc(has_metadata=False, has_baseid=False)
+    doc_2["authz"] = ["resource_B"]
+    res = client.post("/index/" + rec1["did"], json=doc_2, headers=admin_user)
+    assert res.status_code == 200, res.json
+    rec2 = res.json
+    # ----------
+
+    # If user B attempts to update all versions, expect request to fail with 403.
+    update_data = {"authz": ["new_authz"]}
+    res = client.put(
+        "/index/{}/versions".format(rec2["did"]), json=update_data, headers=test_user
+    )
+    assert (
+        res.status_code == 403
+    ), "Expected operation to fail due to lack of user permissions: {}".format(res.json)
 
 
 def test_index_stats(client, user):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1958,6 +1958,7 @@ def test_update_all_versions_fail_on_missing_permissions(client, user, use_mock_
     doc_1["authz"] = ["resource_A"]
     res = client.post("/index/", json=doc_1, headers=admin_user)
     assert res.status_code == 200, res.json
+    rec1 = res.json
 
     # Second version is accessible to test user.
     doc_2 = get_doc(has_metadata=False, has_baseid=False)


### PR DESCRIPTION
Jira Ticket: [PXP-1745](https://ctds-planx.atlassian.net/browse/PXP-1745)

Adds a new endpoint to indexd, PUT `/index/{GUID}/versions`, allowing user to update the `acl` and `authz` fields across all versions of a record.

### New Features
- Added PUT `/index/{GUID}/versions` endpoint, allowing user to update the `acl` and `authz` fields across all versions of a record.

