### PR TITLE
PXP-6156 "authz" for blank endpoints

### DIFF
--- a/indexd/auth/__init__.py
+++ b/indexd/auth/__init__.py
@@ -12,7 +12,7 @@ def authorize(*p):
     Replaces the request authorization with a user context.
     Raises AuthError if authorization fails.
 
-    If called with (method, resource), it will check with Arborist if HTTP Basic Auth is
+    If called with (method, resources), it will check with Arborist if HTTP Basic Auth is
     not present, or fallback to the previous check.
     """
     if len(p) == 1:
@@ -30,10 +30,12 @@ def authorize(*p):
 
         return check_auth
     else:
-        method, resource = p
+        method, resources = p
         if request.authorization:
             current_app.auth.auth(
                 request.authorization.username, request.authorization.password
             )
         else:
-            current_app.auth.authz(method, resource)
+            if not isinstance(resources, list):
+                raise UserError(f"'authz' must be a list, received '{resources}'.")
+            current_app.auth.authz(method, list(set(resources)))

--- a/indexd/auth/__init__.py
+++ b/indexd/auth/__init__.py
@@ -33,7 +33,7 @@ def authorize(*p):
     else:
         method, resource = p
         if request.authorization:
-            request.authorization = current_app.auth.auth(
+            current_app.auth.auth(
                 request.authorization.username, request.authorization.password
             )
         else:

--- a/indexd/auth/__init__.py
+++ b/indexd/auth/__init__.py
@@ -22,10 +22,9 @@ def authorize(*p):
         def check_auth(*args, **kwargs):
             if not request.authorization:
                 raise AuthError("Username / password required.")
-            user = current_app.auth.auth(
+            current_app.auth.auth(
                 request.authorization.username, request.authorization.password
             )
-            request.authorization = user
 
             return f(*args, **kwargs)
 

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -279,19 +279,11 @@ def post_index_blank_record():
     Create a blank new record with only uploader and optionally
     file_name fields filled
     """
-    try:
-        authorize("file_upload", ["/data_file"])
-    except AuthError as err:
-        self.logger.error(
-            f"Auth error when attempting to create a blank record. User "
-            f"does not have access to 'file_upload' for authz resource: /data_file"
-        )
-        raise err
-
     uploader = flask.request.get_json().get("uploader")
     file_name = flask.request.get_json().get("file_name")
     authz = flask.request.get_json().get("authz")
 
+    # authorize done in add_blank_record
     did, rev, baseid = blueprint.index_driver.add_blank_record(
         uploader=uploader, file_name=file_name, authz=authz
     )
@@ -330,21 +322,13 @@ def put_index_blank_record(record):
     """
     Update a blank record with size, hashes and url
     """
-    try:
-        authorize("file_upload", ["/data_file"])
-    except AuthError as err:
-        self.logger.error(
-            f"Auth error when attempting to update a blank record. User "
-            f"does not have access to 'file_upload' for authz resource: /data_file"
-        )
-        raise err
-
     rev = flask.request.args.get("rev")
     size = flask.request.get_json().get("size")
     hashes = flask.request.get_json().get("hashes")
     urls = flask.request.get_json().get("urls")
     authz = flask.request.get_json().get("authz")
 
+    # authorize done in update_blank_record
     did, rev, baseid = blueprint.index_driver.update_blank_record(
         did=record, rev=rev, size=size, hashes=hashes, urls=urls, authz=authz
     )
@@ -364,6 +348,7 @@ def put_index_record(record):
         raise UserError(err)
 
     rev = flask.request.args.get("rev")
+
     # authorize done in update
     did, baseid, rev = blueprint.index_driver.update(record, rev, flask.request.json)
 

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -303,13 +303,14 @@ def add_index_blank_record_version(record):
     Returns the GUID of the new blank version and the baseid common to all versions
     of the record.
     """
+    new_did = flask.request.json.get("did")
     uploader = flask.request.get_json().get("uploader")
     file_name = flask.request.get_json().get("file_name")
-    new_did = flask.request.json.get("did")
+    authz = flask.request.get_json().get("authz")
 
     # authorize done in add_blank_version for the existing record's authz
     did, baseid, rev = blueprint.index_driver.add_blank_version(
-        record, new_did=new_did, uploader=uploader, file_name=file_name
+        record, new_did=new_did, uploader=uploader, file_name=file_name, authz=authz
     )
 
     ret = {"did": did, "baseid": baseid, "rev": rev}

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -329,9 +329,10 @@ def put_index_blank_record(record):
     size = flask.request.get_json().get("size")
     hashes = flask.request.get_json().get("hashes")
     urls = flask.request.get_json().get("urls")
+    authz = flask.request.get_json().get("authz")
 
     did, rev, baseid = blueprint.index_driver.update_blank_record(
-        did=record, rev=rev, size=size, hashes=hashes, urls=urls
+        did=record, rev=rev, size=size, hashes=hashes, urls=urls, authz=authz
     )
     ret = {"did": did, "rev": rev, "baseid": baseid}
 

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -283,9 +283,10 @@ def post_index_blank_record():
 
     uploader = flask.request.get_json().get("uploader")
     file_name = flask.request.get_json().get("file_name")
+    authz = flask.request.get_json().get("authz")
 
     did, rev, baseid = blueprint.index_driver.add_blank_record(
-        uploader=uploader, file_name=file_name
+        uploader=uploader, file_name=file_name, authz=authz
     )
 
     ret = {"did": did, "rev": rev, "baseid": baseid}

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -279,7 +279,14 @@ def post_index_blank_record():
     Create a blank new record with only uploader and optionally
     file_name fields filled
     """
-    authorize("file_upload", ["/data_file"])
+    try:
+        authorize("file_upload", ["/data_file"])
+    except AuthError as err:
+        self.logger.error(
+            f"Auth error when attempting to create a blank record. User "
+            f"does not have access to 'file_upload' for authz resource: /data_file"
+        )
+        raise err
 
     uploader = flask.request.get_json().get("uploader")
     file_name = flask.request.get_json().get("file_name")
@@ -323,7 +330,14 @@ def put_index_blank_record(record):
     """
     Update a blank record with size, hashes and url
     """
-    authorize("file_upload", ["/data_file"])
+    try:
+        authorize("file_upload", ["/data_file"])
+    except AuthError as err:
+        self.logger.error(
+            f"Auth error when attempting to update a blank record. User "
+            f"does not have access to 'file_upload' for authz resource: /data_file"
+        )
+        raise err
 
     rev = flask.request.args.get("rev")
     size = flask.request.get_json().get("size")

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1366,7 +1366,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             )
 
             # User requires update permissions for all versions of the record
-            all_resources = {resource for rec in records for resource in rec.authz}
+            all_resources = {r.resource for rec in records for r in rec.authz}
             auth.authorize("update", list(all_resources))
 
             ret = []

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -224,7 +224,7 @@ paths:
       tags:
         - index
       summary: Create a blank record
-      description: ''
+      description: An authz can optionally be specified.
       operationId: createBlankEntry
       produces:
         - application/json
@@ -249,7 +249,7 @@ paths:
       tags:
         - index
       summary: Create a new, blank version for the document associated to the provided uuid.
-      description: Creates a new blank version of a record with the provided GUID. Returns the GUID of the new version of the record and the baseid common to all versions of the record. Authorization (acl/authz fields) carry over from the original record to the new blank version. No other metadata (md5sum, etc) carries over from the original record to the new blank version.
+      description: Creates a new blank version of a record with the provided GUID. Returns the GUID of the new version of the record and the baseid common to all versions of the record. Authorization (acl/authz fields) carry over from the original record to the new blank version, unless an authz is provided. No other metadata (md5sum, etc) carries over from the original record to the new blank version.
       operationId: addNewBlankVersion
       consumes:
         - application/json
@@ -281,7 +281,7 @@ paths:
     put:
       tags:
         - index
-      summary: Update only hashes and size for blank index
+      summary: Update only hashes, size and optionally urls and authz for blank index
       description: ''
       operationId: updateBlankEntry
       consumes:
@@ -1344,18 +1344,28 @@ definitions:
       file_name:
         type: string
         description: name of the uploaded file
+      authz:
+        description: optional
+        type: array
+        items:
+          type: string
   InputBlankVersionInfo:
     type: object
     properties:
+      did:
+        type: string
+        description: optional; specify the GUID of the new blank version that is created.
       uploader:
         type: string
         description: user who uploaded this file
       file_name:
         type: string
         description: optional; name of the uploaded file
-      did:
-        type: string
-        description: optional; specify the GUID of the new blank version that is created.
+      authz:
+        description: optional
+        type: array
+        items:
+          type: string
   UpdateInputInfo:
     type: object
     properties:
@@ -1387,6 +1397,11 @@ definitions:
       hashes:
         $ref: '#/definitions/HashInfo'
       urls:
+        type: array
+        items:
+          type: string
+      authz:
+        description: optional
         type: array
         items:
           type: string

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,6 @@ pytest==3.0.6
 pytest-cov==2.5.1
 pytest-flask==0.8.1
 PyYAML==5.1
-swagger_spec_validator
+swagger_spec_validator==2.6.0
 responses
 -e git+https://github.com/uc-cdis/cdisutils-test.git@1.0.0#egg=cdisutilstest

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -581,7 +581,6 @@ def test_create_blank_record_with_authz(client, user):
     Test that new blank records only contain the uploader
     and optionally file_name fields: test with file name
     """
-
     doc = {"uploader": "uploader1", "authz": ["/programs/A"]}
     res = client.post("/index/blank/", json=doc, headers=user)
     assert res.status_code == 201
@@ -957,7 +956,7 @@ def test_update_blank_record_with_authz(client, user):
     rec = res.json
     assert rec["size"] == 10
     assert rec["hashes"]["md5"] == "8b9942cf415384b27cadf1f4d2d981f5"
-    assert rec["authz"] == ["/programs/A"]
+    assert rec["authz"] == ["/programs/A"]  # authz as provided
 
 
 def test_update_blank_record_with_new_authz(client, user):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -577,27 +577,55 @@ def test_create_blank_record_with_file_name(client, user):
     assert_blank(rec)
 
 
-def test_create_blank_record_with_authz(client, user):
+def test_create_blank_record_with_authz(client, use_mock_authz):
     """
-    Test that new blank records only contain the uploader
-    and optionally file_name fields: test with file name
+    Test that a new blank record can be created with a specified
+    authz when the user has the expected access
     """
-    doc = {"uploader": "uploader1", "authz": ["/programs/A"]}
-    res = client.post("/index/blank/", json=doc, headers=user)
-    assert res.status_code == 201
+    old_authz = "/programs/A"
+    new_authz = "/programs/B"
+
+    # - user has create access on the resource
+    use_mock_authz([("create", old_authz)])
+    doc = {"uploader": "uploader1", "authz": [old_authz]}
+    res = client.post("/index/blank/", json=doc)
+    assert res.status_code == 201, res.json
     rec = res.json
     assert rec["did"]
     assert rec["rev"]
     assert rec["baseid"]
 
     res = client.get("/index/" + rec["did"])
-    assert res.status_code == 200
+    assert res.status_code == 200, res.json
     rec = res.json
     assert rec["uploader"] == "uploader1"
-    assert rec["authz"] == ["/programs/A"]  # authz as provided
+    assert rec["authz"] == [old_authz]  # authz as provided
+    assert_blank(rec, with_authz=True)  # test that record is blank
 
-    # test that record is blank
-    assert_blank(rec, with_authz=True)
+    # - user doesn't have create access on the resource:
+    #   fall back on `file_upload` on `/data_file` access
+    use_mock_authz([("file_upload", "/data_file")])
+    doc = {"uploader": "uploader1", "authz": [new_authz]}
+    res = client.post("/index/blank/", json=doc)
+    assert res.status_code == 201, res.json
+    rec = res.json
+    assert rec["did"]
+    assert rec["rev"]
+    assert rec["baseid"]
+
+    res = client.get("/index/" + rec["did"])
+    assert res.status_code == 200, res.json
+    rec = res.json
+    assert rec["uploader"] == "uploader1"
+    assert rec["authz"] == [new_authz]  # authz as provided
+    assert_blank(rec, with_authz=True)  # test that record is blank
+
+    # - user has neither create access on the resource or
+    #   `file_upload` on `/data_file` access: unauthorized
+    use_mock_authz([])
+    doc = {"uploader": "uploader1", "authz": [new_authz]}
+    res = client.post("/index/blank/", json=doc)
+    assert res.status_code == 403, res.json
 
 
 def test_create_blank_version(client, user):
@@ -670,38 +698,49 @@ def test_create_blank_version(client, user):
         assert not blank_doc[field]
 
 
-def test_create_blank_version_with_authz(client, user):
+def test_create_blank_version_with_authz(client, user, use_mock_authz):
     """
-    Test that we can create a new, blank version of a record
-    with POST /index/blank/{GUID} and specify the authz.
+    Test that a new version of a blank record can be created with a
+    different authz when the user has the expected access
     """
+    old_authz = "/programs/A"
+    new_authz = "/programs/B"
+
     # add an original record to the index
     doc = get_doc()
-    doc["authz"] = ["programs/A"]
+    doc["authz"] = [old_authz]
     res = client.post("/index/", json=doc, headers=user)
-    assert res.status_code == 200, "Failed to add original doc to index"
+    assert res.status_code == 200, res.json
     original_guid = res.json["did"]
     res = client.get("/index/{}".format(original_guid))
-    assert res.status_code == 200, "Failed to find original doc in index"
+    assert res.status_code == 200, res.json
     baseid = res.json["baseid"]
-    assert res.json["authz"] == ["programs/A"]
+    assert res.json["authz"] == [old_authz]
 
-    # make a new blank version of the original record
-    payload = {"uploader": "uploader1", "authz": ["programs/B"]}
+    # - user has create access on the new resource but doesn't
+    #   have update access on the old resource
+    # should fail to make a new blank version of the original record
+    use_mock_authz([("create", new_authz)])
+    payload = {"uploader": "uploader1", "authz": [new_authz]}
     url = "/index/blank/{}".format(original_guid)
-    res = client.post(url, json=payload, headers=user)
-    assert res.status_code == 201, "Failed to make new blank version: {}".format(
-        res.json
-    )
+    res = client.post(url, json=payload)
+    assert res.status_code == 403, res.json
+
+    # - user has the required "create" and "update" access
+    # make a new blank version of the original record
+    use_mock_authz([("create", new_authz), ("update", old_authz)])
+    url = "/index/blank/{}".format(original_guid)
+    res = client.post(url, json=payload)
+    assert res.status_code == 201, res.json
     res = client.get("/index/{}".format(res.json["did"]))
-    assert res.status_code == 200, "Failed to find blank record: {}".format(res.json)
+    assert res.status_code == 200, res.json
     new_version = res.json
 
     # check non-blank fields
     assert new_version["did"]
     assert new_version["rev"]
     assert new_version["baseid"] == baseid
-    assert new_version["authz"] == ["programs/B"]  # authz as provided
+    assert new_version["authz"] == [new_authz]  # authz as provided
 
     # check blank fields
     blank_fields = [
@@ -924,78 +963,128 @@ def test_fill_size_n_hash_for_blank_record(client, user):
     assert rec["hashes"]["md5"] == "8b9942cf415384b27cadf1f4d2d981f5"
 
 
-def test_update_blank_record_with_authz(client, user):
+def test_update_blank_record_with_authz(client, user, use_mock_authz):
     """
-    Test that can add an authz when updating size and hashes of a
-    blank record WITHOUT existing authz
+    Test that a blank record (WITHOUT AUTHZ) can be updated
+    with an authz when the user has the expected access
     """
+    new_authz = "/programs/A"
+    new_authz2 = "/programs/B"
+
     # create a blank record
     doc = {"uploader": "uploader_1"}
     res = client.post("/index/blank/", json=doc, headers=user)
-    assert res.status_code == 201
+    assert res.status_code == 201, res.json
     rec = res.json
     assert rec["did"]
     assert rec["rev"]
     did, rev = rec["did"], rec["rev"]
 
-    # update the blank record
-    updated = {
-        "size": 10,
-        "hashes": {"md5": "8b9942cf415384b27cadf1f4d2d981f5"},
-        "authz": ["/programs/A"],
+    # - user doesn't have update access on the resource
+    # should fail to make a new blank version of the original record
+    use_mock_authz([])
+    to_update = {
+        "authz": [new_authz],
     }
-    res = client.put(
-        "/index/blank/{}?rev={}".format(did, rev), headers=user, json=updated
-    )
-    assert res.status_code == 200
+    res = client.put("/index/blank/{}?rev={}".format(did, rev), json=to_update)
+    assert res.status_code == 403, res.json
+
+    # - user has update access on the new resource
+    # update the blank record
+    use_mock_authz([("update", new_authz)])
+    res = client.put("/index/blank/{}?rev={}".format(did, rev), json=to_update)
+    assert res.status_code == 200, res.json
+    rec = res.json
+    assert rec["did"] == did
+    assert rec["rev"] != rev
+    rev = rec["rev"]
+
+    res = client.get("/index/" + did)
+    assert res.status_code == 200, res.json
+    rec = res.json
+    assert rec["authz"] == [new_authz]  # authz as provided
+
+    # - user doesn't have update access on the resource:
+    #   fall back on `file_upload` on `/data_file` access
+    # update the blank record
+    use_mock_authz([("file_upload", "/data_file")])
+    to_update = {
+        "authz": [new_authz2],
+    }
+    res = client.put("/index/blank/{}?rev={}".format(did, rev), json=to_update)
+    assert res.status_code == 200, res.json
     rec = res.json
     assert rec["did"] == did
     assert rec["rev"] != rev
 
     res = client.get("/index/" + did)
-    assert res.status_code == 200
+    assert res.status_code == 200, res.json
     rec = res.json
-    assert rec["size"] == 10
-    assert rec["hashes"]["md5"] == "8b9942cf415384b27cadf1f4d2d981f5"
-    assert rec["authz"] == ["/programs/A"]  # authz as provided
+    assert rec["authz"] == [new_authz2]  # authz as provided
 
 
-def test_update_blank_record_with_new_authz(client, user):
+def test_update_blank_record_with_authz_new(client, user, use_mock_authz):
     """
-    Test that can add an authz when updating size and hashes of a
-    blank record WITH existing authz
+    Test that a blank record (WITH AUTHZ) can be updated
+    with a different authz when the user has the expected access
     """
+    old_authz = "/programs/A"
+    new_authz = "/programs/B"
+    new_authz2 = "/programs/C"
+
     # create a blank record
-    doc = {"uploader": "uploader_1", "authz": ["/programs/A"]}
+    doc = {"uploader": "uploader_1", "authz": [old_authz]}
     res = client.post("/index/blank/", json=doc, headers=user)
-    assert res.status_code == 201
+    assert res.status_code == 201, res.json
     rec = res.json
     assert rec["did"]
     assert rec["rev"]
     did, rev = rec["did"], rec["rev"]
     res = client.get("/index/{}".format(did))
-    assert res.json["authz"] == ["/programs/A"]  # authz as provided
+    assert res.json["authz"] == [old_authz]  # authz as provided
 
-    # update the blank record
-    updated = {
-        "size": 10,
-        "hashes": {"md5": "8b9942cf415384b27cadf1f4d2d981f5"},
-        "authz": ["/programs/B"],
+    # - user has update access on the new resource but doesn't
+    #   have update access on the old resource
+    # should fail to make a new blank version of the original record
+    use_mock_authz([("update", new_authz)])
+    to_update = {
+        "authz": [new_authz],
     }
-    res = client.put(
-        "/index/blank/{}?rev={}".format(did, rev), headers=user, json=updated
-    )
-    assert res.status_code == 200
+    res = client.put("/index/blank/{}?rev={}".format(did, rev), json=to_update)
+    assert res.status_code == 403, res.json
+
+    # - user has the required "update" and "update" access
+    # update the blank record
+    use_mock_authz([("update", new_authz), ("update", old_authz)])
+    res = client.put("/index/blank/{}?rev={}".format(did, rev), json=to_update)
+    assert res.status_code == 200, res.json
+    rec = res.json
+    assert rec["did"] == did
+    assert rec["rev"] != rev
+    rev = rec["rev"]
+
+    res = client.get("/index/" + did)
+    assert res.status_code == 200, res.json
+    rec = res.json
+    assert rec["authz"] == [new_authz]  # authz as provided
+
+    # - user doesn't have update access on the resources:
+    #   fall back on `file_upload` on `/data_file` access
+    # update the blank record
+    use_mock_authz([("file_upload", "/data_file")])
+    to_update = {
+        "authz": [new_authz2],
+    }
+    res = client.put("/index/blank/{}?rev={}".format(did, rev), json=to_update)
+    assert res.status_code == 200, res.json
     rec = res.json
     assert rec["did"] == did
     assert rec["rev"] != rev
 
     res = client.get("/index/" + did)
-    assert res.status_code == 200
+    assert res.status_code == 200, res.json
     rec = res.json
-    assert rec["size"] == 10
-    assert rec["hashes"]["md5"] == "8b9942cf415384b27cadf1f4d2d981f5"
-    assert rec["authz"] == ["/programs/B"]  # authz as provided
+    assert rec["authz"] == [new_authz2]  # authz as provided
 
 
 def test_get_empty_acl_authz_record(client, user):
@@ -1129,19 +1218,7 @@ def test_get_empty_acl_authz_record_after_fill_size_n_hash(client, user):
     assert len(ids) == 2
 
 
-def test_bad_update_blank_record(client, user):
-    doc = {"file_name": "test_file_name_1", "uploader": "test_uploader_1"}
-    res = client.post("/index/blank", json=doc, headers=user)
-    assert res.status_code == 201
-    rec = res.json
-
-    # test that empty update throws 400 error
-    data = {"size": "", "hashes": {"": ""}}
-    res = client.put(
-        "/index/blank/{}?rev={}".format(rec["did"], rec["rev"]), json=data, headers=user
-    )
-    assert res.status_code == 400
-
+def test_cant_update_inexistent_blank_record(client, user):
     # test that non-existent did throws 400 error
     data = {"size": 123, "hashes": {"md5": "8b9942cf415384b27cadf1f4d2d682e5"}}
     fake_did = "testprefix:455ffb35-1b0e-49bd-a4ab-3afe9f3aece9"
@@ -1692,14 +1769,16 @@ def test_index_add_prefix_alias(client, user):
 
 
 def test_index_update(client, user):
+    # create record
     data = get_doc()
-
     res = client.post("/index/", json=data, headers=user)
     assert res.status_code == 200
     rec = res.json
     assert rec["did"]
     assert rec["rev"]
     assert client.get("/index/" + rec["did"]).json["metadata"] == data["metadata"]
+
+    # update record
     dataNew = get_doc()
     del dataNew["hashes"]
     del dataNew["size"]
@@ -1714,6 +1793,8 @@ def test_index_update(client, user):
     assert res_2.status_code == 200
     rec_2 = res_2.json
     assert rec_2["rev"] != rec["rev"]
+
+    # check record was updated
     response = client.get("/index/" + rec_2["did"])
     assert response.status_code == 200
     record = response.json
@@ -1721,6 +1802,7 @@ def test_index_update(client, user):
     assert record["acl"] == dataNew["acl"]
     assert record["authz"] == dataNew["authz"]
 
+    # create record
     data = get_doc()
     data["did"] = "cdis:3d313755-cbb4-4b08-899d-7bbac1f6e67d"
     res = client.post("/index/", json=data, headers=user)
@@ -1728,6 +1810,8 @@ def test_index_update(client, user):
     rec = res.json
     assert rec["did"]
     assert rec["rev"]
+
+    # update record
     dataNew = {
         "urls": ["s3://endpointurl/bucket/key"],
         "file_name": "test",
@@ -1739,6 +1823,41 @@ def test_index_update(client, user):
     assert res_2.status_code == 200
     rec_2 = res_2.json
     assert rec_2["rev"] != rec["rev"]
+
+
+def test_index_update_with_authz_check(client, user, use_mock_authz):
+    old_authz = "/programs/A"
+    new_authz = "/programs/B"
+
+    # create record
+    data = get_doc()
+    data["authz"] = [old_authz]
+    res = client.post("/index/", json=data, headers=user)
+    assert res.status_code == 200, res.json
+    rec = res.json
+    assert rec["did"]
+    assert rec["rev"]
+    rev = rec["rev"]
+
+    # user doesn't have all the required access: cannot update record
+    use_mock_authz([("update", new_authz)])
+    to_update = {"authz": [new_authz]}
+    res = client.put("/index/{}?rev={}".format(rec["did"], rev), json=to_update)
+    assert res.status_code == 403, res.json
+
+    # user has all the required access: can update record
+    use_mock_authz([("update", new_authz), ("update", old_authz)])
+    to_update = {"authz": [new_authz]}
+    res = client.put("/index/{}?rev={}".format(rec["did"], rev), json=to_update)
+    assert res.status_code == 200, res.json
+    rec = res.json
+    assert rec["rev"] != rev
+
+    # check record was updated
+    res = client.get("/index/" + rec["did"])
+    assert res.status_code == 200, res.json
+    rec = res.json
+    assert rec["authz"] == [new_authz]
 
 
 def test_index_update_duplicate_acl_authz(client, user):

--- a/tests/util.py
+++ b/tests/util.py
@@ -29,16 +29,31 @@ class removes(object):
         return wrapper
 
 
-def assert_blank(r):
+def assert_blank(record, with_authz=False):
     """
     Check that the fields that should be empty in a
     blank record are empty.
+
+    Args:
+        r (dict): either an indexd record or a JSON response
+            such as { "records": [ { <indexd record } ] }
+            (only the first record is validated).
+        with_authz (bool, optional): Whether the record should contain
+            an authz. Defaults to False.
     """
-    assert r["records"][0]["baseid"]
-    assert r["records"][0]["did"]
-    assert not r["records"][0]["size"]
-    assert not r["records"][0]["acl"]
-    assert not r["records"][0]["authz"]
-    assert not r["records"][0]["hashes"]
-    assert not r["records"][0]["urls_metadata"]
-    assert not r["records"][0]["version"]
+    # handle passing an indexd JSON response directly
+    if "records" in record:
+        record = record["records"][0]
+
+    assert record["baseid"]
+    assert record["did"]
+    assert not record["size"]
+    assert not record["acl"]
+    assert not record["hashes"]
+    assert not record["urls_metadata"]
+    assert not record["version"]
+
+    if with_authz:
+        assert record["authz"]
+    else:
+        assert not record["authz"]


### PR DESCRIPTION
Jira Ticket: [PXP-6156](https://ctds-planx.atlassian.net/browse/PXP-6156)

closes #278

- `authz` for blank endpoints
- Fix bug when `authorize()` is called more than once
- Fix bug in `update_all_versions` authz check
- Pin `swagger_spec_validator` to 2.6.0 because version 2.7.0 fails with:
```
    def test_valid_openapi():
        [...]
>       validator.validate_spec(spec, url)

    def validate_definition(definition, deref, def_name=None, visited_definitions_ids=None):
        [...]
>       swagger_type = definition.get('type')
E       AttributeError: 'bool' object has no attribute 'get'
```

### New Features
- "POST /blank", "POST /blank/GUID" and "PUT /blank/GUID" endpoints now allow specifying an authz for the blank record
- "PUT /index/GUID" (record update) now checks authorization for both update (old authz) and create (new authz)