### PR TITLE
Fix ACL->authz migration script for "[ project, program ]" ACLs

### DIFF
--- a/bin/migrate_acl_authz.py
+++ b/bin/migrate_acl_authz.py
@@ -199,13 +199,12 @@ class ACLConverter(object):
                 # if there's a * it should just be open. return early
                 path = "/open"
                 break
-            elif not self.use_sheepdog_db or (
-                projects_found == 0 and self.is_program(acl_item)
-            ):
+            elif not self.use_sheepdog_db or self.is_program(acl_item):
                 # if we don't have sheepdog we have to assume everything is a "program".
-                # also, we only want to set the path to a program if we haven't found a
-                # path for a project already.
-                path = "/programs/{}".format(acl_item)
+                if projects_found == 0:
+                    # we only want to set the path to a program if we haven't found a
+                    # path for a project already.
+                    path = "/programs/{}".format(acl_item)
                 programs_found += 1
             elif acl_item in self.projects:
                 # always want to update to project if possible

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask==1.1.1
 jsonschema==2.5.1
 sqlalchemy==1.3.3
-sqlalchemy-utils>=0.33.11
+sqlalchemy-utils>=0.33.11,<=0.36.6
 psycopg2>=2.7
 git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
 git+https://github.com/uc-cdis/indexclient.git@1.6.0#egg=indexclient

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
         "flask==1.1.1",
         "jsonschema==2.5.1",
         "sqlalchemy==1.3.3",
-        "sqlalchemy-utils>=0.33.11",
+        "sqlalchemy-utils>=0.33.11,<=0.36.6",
         "psycopg2>=2.7",
         "cdislogging>=0.0.2",
         "indexclient",


### PR DESCRIPTION
Fix migration script:
- For ACL `['PROG', 'PROJ']` we get path = `/programs/PROG/projects/PROJ`
- For ACL `['PROJ', 'PROG']` we get `EnvironmentError: program or project PROG does not exist`

The script will also now raise an error for ACL `[<project that exists>, <program that doesn't exist>]` instead of just using the project to generate the path

Also, `sqlalchemy-utils 0.36.8` is breaking indexd: `FATAL:  database "indexd_user" does not exist`
so limiting to working versions `sqlalchemy-utils>=0.33.11,<=0.36.6`
see https://github.com/kvesteri/sqlalchemy-utils/issues/462

### Bug Fixes
- Fix ACL->authz migration script for "[ project, program ]" ACLs

### Dependency updates
- Add sqlalchemy-utils upper bound "<=0.36.6" in addition to ">=0.33.11"