### PR TITLE
Return 409 in case of conflict

### DIFF
--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -307,9 +307,10 @@ def post_index_blank_record():
     Create a blank new record with only uploader and optionally
     file_name fields filled
     """
-    uploader = flask.request.get_json().get("uploader")
-    file_name = flask.request.get_json().get("file_name")
-    authz = flask.request.get_json().get("authz")
+    body = flask.request.get_json() or {}
+    uploader = body.get("uploader")
+    file_name = body.get("file_name")
+    authz = body.get("authz")
 
     # authorize done in add_blank_record
     did, rev, baseid = blueprint.index_driver.add_blank_record(
@@ -330,10 +331,11 @@ def add_index_blank_record_version(record):
     Returns the GUID of the new blank version and the baseid common to all versions
     of the record.
     """
-    new_did = flask.request.json.get("did")
-    uploader = flask.request.get_json().get("uploader")
-    file_name = flask.request.get_json().get("file_name")
-    authz = flask.request.get_json().get("authz")
+    body = flask.request.get_json() or {}
+    new_did = body.get("did")
+    uploader = body.get("uploader")
+    file_name = body.get("file_name")
+    authz = body.get("authz")
 
     # authorize done in add_blank_version for the existing record's authz
     did, baseid, rev = blueprint.index_driver.add_blank_version(
@@ -351,10 +353,12 @@ def put_index_blank_record(record):
     Update a blank record with size, hashes and url
     """
     rev = flask.request.args.get("rev")
-    size = flask.request.get_json().get("size")
-    hashes = flask.request.get_json().get("hashes")
-    urls = flask.request.get_json().get("urls")
-    authz = flask.request.get_json().get("authz")
+
+    body = flask.request.get_json() or {}
+    size = body.get("size")
+    hashes = body.get("hashes")
+    urls = body.get("urls")
+    authz = body.get("authz")
 
     # authorize done in update_blank_record
     did, rev, baseid = blueprint.index_driver.update_blank_record(
@@ -603,7 +607,7 @@ def compute_checksum(checksums):
 
     Args:
         checksums (list): list of checksums from the first layer of bundles and objects
-    
+
     Returns:
         md5 checksum
     """

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -247,7 +247,7 @@ class IndexRecordHash(Base):
 
 class DrsBundleRecord(Base):
     """
-    DRS bundle record representaion. 
+    DRS bundle record representation.
     """
 
     __tablename__ = "drs_bundle_record"
@@ -1533,7 +1533,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         aliases=None,
     ):
         """
-        Add a bundle record 
+        Add a bundle record
         """
         with self.session as session:
             record = DrsBundleRecord()

--- a/tests/test_aliases_endpoints.py
+++ b/tests/test_aliases_endpoints.py
@@ -242,7 +242,7 @@ def test_POST_aliases_invalid_GUID(client, user, guid, aliases, unused_aliases):
 
 def test_POST_aliases_nonunique_aliases(client, user, guid, aliases, unused_aliases):
     """
-    expect to return 400 and have no effect if valid GUID but one or more aliases
+    expect to return 409 and have no effect if valid GUID but one or more aliases
     already associated with another GUID
     """
     guid_A = guid
@@ -259,7 +259,7 @@ def test_POST_aliases_nonunique_aliases(client, user, guid, aliases, unused_alia
     res = client.post(
         get_endpoint(guid_A), json=to_payload(unused_aliases), headers=user
     )
-    assert res.status_code == 400, res.text
+    assert res.status_code == 409, res.json
 
     # expect aliases that were already associated with guid_A to be unchanged.
     res = client.get(get_endpoint(guid_A))
@@ -273,24 +273,24 @@ def test_POST_aliases_nonunique_aliases(client, user, guid, aliases, unused_alia
 
 def test_POST_aliases_GUID_already_has_alias(client, user, guid, aliases):
     """
-    expect to return 400 and have no effect if valid GUID and one or more aliases
+    expect to return 409 and have no effect if valid GUID and one or more aliases
     already associated with this GUID
     """
     # pick a subset of the aliases already associated with this GUID
     subset_old_aliases = aliases[0:1]
 
-    # expect a POST request with the new subset of aliases to fail with 400
+    # expect a POST request with the new subset of aliases to fail with 409
     res = client.post(
         get_endpoint(guid), json=to_payload(subset_old_aliases), headers=user
     )
-    assert res.status_code == 400, res.text
+    assert res.status_code == 409, res.json
 
 
 def test_POST_aliases_duplicate_aliases_in_request(
     client, user, guid, aliases, unused_aliases
 ):
     """
-    expect to fail with 400 if valid GUID and one or more aliases duplicated
+    expect to fail with 409 if valid GUID and one or more aliases duplicated
     in request
     """
     new_aliases = unused_aliases
@@ -304,7 +304,7 @@ def test_POST_aliases_duplicate_aliases_in_request(
     res = client.post(
         get_endpoint(guid), json=to_payload(duplicated_new_aliases), headers=user
     )
-    assert res.status_code == 400, res.text
+    assert res.status_code == 409, res.json
 
     # expect aliases in db to be unchanged
     res = client.get(get_endpoint(guid))
@@ -411,7 +411,7 @@ def test_PUT_aliases_invalid_GUID(client, user, guid, aliases, unused_aliases):
 
 def test_PUT_aliases_nonunique_aliases(client, user, guid, aliases, unused_aliases):
     """
-    expect to return 400 and have no effect if valid GUID but one or more aliases
+    expect to return 409 and have no effect if valid GUID but one or more aliases
     already associated with another GUID
     """
     new_aliases = unused_aliases
@@ -426,7 +426,7 @@ def test_PUT_aliases_nonunique_aliases(client, user, guid, aliases, unused_alias
     # expect that an attempt to add the original set of random aliases
     # will fail, as some of the aliases are already assigned to a different GUID.
     res = client.put(get_endpoint(guid), json=to_payload(new_aliases), headers=user)
-    assert res.status_code == 400, res.text
+    assert res.status_code == 409, res.json
 
     # expect aliases that were already associated with GUID to be unchanged.
     res = client.get(get_endpoint(guid))
@@ -492,7 +492,7 @@ def test_PUT_aliases_duplicate_aliases_in_request(
     client, user, guid, aliases, unused_aliases
 ):
     """
-    expect to fail with 400 if valid GUID and one or more aliases duplicated
+    expect to fail with 409 if valid GUID and one or more aliases duplicated
     in request
     """
     new_aliases = unused_aliases
@@ -506,7 +506,7 @@ def test_PUT_aliases_duplicate_aliases_in_request(
     res = client.put(
         get_endpoint(guid), json=to_payload(duplicated_new_aliases), headers=user
     )
-    assert res.status_code == 400, res.text
+    assert res.status_code == 409, res.json
 
 
 def test_PUT_aliases_valid_GUID_empty_aliases(client, user, guid, aliases):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -923,7 +923,7 @@ def test_create_blank_version_specify_did(client, user):
 def test_create_blank_version_specify_guid_already_exists(client, user):
     """
     Test that if we try to specify the GUID of a new blank version, but the
-    new GUID we specified already exists in the index, the operation fails with 400.
+    new GUID we specified already exists in the index, the operation fails with 409.
     """
     # SETUP
     # ----------
@@ -958,25 +958,25 @@ def test_create_blank_version_specify_guid_already_exists(client, user):
     # -----------
 
     # Attempt to create new blank version of doc, specifying the new guid to be
-    # a guid that already exists in the index. Expect the operation to fail with 400.
+    # a guid that already exists in the index. Expect the operation to fail with 409.
     specified_guid = preexisting_guid
     doc = {"uploader": "uploader_123", "file_name": "test_file", "did": specified_guid}
     url = "/index/blank/{}".format(original_doc["did"])
     res = client.post(url, json=doc, headers=user)
     assert (
-        res.status_code == 400
-    ), "Request should have failed with 400 user error: {}".format(res.json)
+        res.status_code == 409
+    ), "Request should have failed with 409 user error: {}".format(res.json)
 
     # Attempt to create new blank version of doc, specifying the new guid to be
     # the guid of the original record we're making a new blank version of.
-    # Expect the operation to fail with 400.
+    # Expect the operation to fail with 409.
     specified_guid = original_doc_guid
     doc = {"uploader": "uploader_123", "file_name": "test_file", "did": specified_guid}
     url = "/index/blank/{}".format(original_doc["did"])
     res = client.post(url, json=doc, headers=user)
     assert (
-        res.status_code == 400
-    ), "Request should have failed with 400 user error: {}".format(res.json)
+        res.status_code == 409
+    ), "Request should have failed with 409 user error: {}".format(res.json)
 
 
 def test_create_blank_version_no_existing_record(client, user):
@@ -1792,7 +1792,7 @@ def test_index_create_with_duplicate_did(client, user):
     response = client.post("/index/", json=data, headers=user)
     assert response.status_code == 200
     response = client.post("/index/", json=data, headers=user)
-    assert response.status_code == 400
+    assert response.status_code == 409
 
 
 def test_index_create_with_file_name(client, user):

--- a/tests/test_driver_alchemy_crud.py
+++ b/tests/test_driver_alchemy_crud.py
@@ -179,7 +179,7 @@ def test_driver_add_bundles_record():
 
         driver = SQLAlchemyIndexDriver("sqlite:///index.sq3")
 
-        driver.add_bundle(name="bundle",)
+        driver.add_bundle(name="bundle")
 
         count = conn.execute(
             """

--- a/tests/test_driver_alchemy_crud.py
+++ b/tests/test_driver_alchemy_crud.py
@@ -8,7 +8,7 @@ import tests.util as util
 from indexd.index.errors import NoRecordFound
 from indexd.index.errors import RevisionMismatch
 
-from indexd.errors import UserError
+from indexd.index.errors import MultipleRecordsFound
 
 from indexd.index.drivers.alchemy import SQLAlchemyIndexDriver, IndexRecord
 
@@ -258,7 +258,7 @@ def test_driver_add_with_duplicate_did():
     did = "3d313755-cbb4-4b08-899d-7bbac1f6e67d"
     driver.add(form, did=did)
 
-    with pytest.raises(UserError):
+    with pytest.raises(MultipleRecordsFound):
         driver.add(form, did=did)
 
 


### PR DESCRIPTION
- Fix 500 error when indexd blank endpoints are called without a body: `AttributeError: 'NoneType' object has no attribute 'get'`
- Return 400 instead of 409 in case of conflict (records / aliases): `MultipleRecordsFound` instead of `UserError`

### Bug Fixes
- Fix 500 error when indexd blank endpoints are called without a body

### Improvements
- Return 400 instead of 409 in case of conflict
