### PR TITLE
(PXP-6604) DRS endpoint to resolve regardless of prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ The prefix that a given Indexd instance uses is specified in the `DEFAULT_PREFIX
 
 The `ADD_PREFIX_ALIAS` configuration represents a different way of using the prefix: if set to `True`, instead of prepending the prefix to the GUID, indexd will create an alias of the form `<prefix><GUID>` for this record. Note that you should NOT set both `ADD_PREFIX_ALIAS` and `PREPEND_PREFIX` to `True`, or aliases will be created as `<prefix><prefix><GUID>`.
 
+If a `DEFAULT_PREFIX` is configured, certain endpoints may take extra steps to resolve a local GUID based on this. The GET `/{GUID}`, `/index/{GUID}`, and DRS endpoints will all accept either the prefixed or unprefixed version of the GUID, regardless of whether the `PREPEND_PREFIX` or `ADD_PREFIX_ALIAS` condiguration is being used. However, any other endpoint that takes a GUID will only accept the exact `did` as stored in the database, so it is best to use that field from the record for subsequent requests.
+
 ## Use Cases For Indexing Data
 
 Data may be loaded into Indexd through a few different means:

--- a/indexd/blueprint.py
+++ b/indexd/blueprint.py
@@ -51,7 +51,7 @@ def get_record(record):
     """
 
     try:
-        ret = blueprint.index_driver.get(record)
+        ret = blueprint.index_driver.get_with_nonstrict_prefix(record)
     except IndexNoRecordFound:
         try:
             ret = blueprint.index_driver.get_by_alias(record)

--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -23,13 +23,13 @@ def get_drs_object(object_id):
         ret = blueprint.index_driver.get(object_id)
     except IndexNoRecordFound as e:
         DEFAULT_PREFIX = blueprint.index_driver.config.get("DEFAULT_PREFIX")
-        match = re.match(r"(dg\.[0-9a-f]{4})\/(.+)", object_id)
+        match = re.match(r"(dg\.[0-9a-f]{4}\/)(.+)", object_id)
         if match and match.group(1) == DEFAULT_PREFIX:
             # If prefix provided matches default, try resolving without
             ret = blueprint.index_driver.get(match.group(2))
         elif match is None:
             # If no prefix provided, try resolving by prepending default
-            ret = blueprint.index_driver.get(DEFAULT_PREFIX + "/" + object_id)
+            ret = blueprint.index_driver.get(DEFAULT_PREFIX + object_id)
         else:
             # If non-default prefix provided, raise original error
             raise e

--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -18,21 +18,7 @@ def get_drs_object(object_id):
     """
     expand = True if flask.request.args.get("expand") == "true" else False
 
-    try:
-        # Try to resolve id as provided
-        ret = blueprint.index_driver.get(object_id)
-    except IndexNoRecordFound as e:
-        DEFAULT_PREFIX = blueprint.index_driver.config.get("DEFAULT_PREFIX")
-        match = re.match(r"(dg\.[0-9a-f]{4}\/)(.+)", object_id)
-        if match and match.group(1) == DEFAULT_PREFIX:
-            # If prefix provided matches default, try resolving without
-            ret = blueprint.index_driver.get(match.group(2))
-        elif match is None:
-            # If no prefix provided, try resolving by prepending default
-            ret = blueprint.index_driver.get(DEFAULT_PREFIX + object_id)
-        else:
-            # If non-default prefix provided, raise original error
-            raise e
+    blueprint.index_driver.get_with_nonstrict_prefix(object_id)
 
     data = indexd_to_drs(ret, expand=expand, list_drs=False)
 

--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -18,7 +18,7 @@ def get_drs_object(object_id):
     """
     expand = True if flask.request.args.get("expand") == "true" else False
 
-    blueprint.index_driver.get_with_nonstrict_prefix(object_id)
+    ret = blueprint.index_driver.get_with_nonstrict_prefix(object_id)
 
     data = indexd_to_drs(ret, expand=expand, list_drs=False)
 

--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -1,5 +1,4 @@
 import flask
-import re
 from indexd.errors import AuthError, AuthzError
 from indexd.errors import UserError
 from indexd.index.errors import NoRecordFound as IndexNoRecordFound

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -248,7 +248,7 @@ def get_index_record(record):
     Returns a record.
     """
 
-    ret = blueprint.index_driver.get(record)
+    ret = blueprint.index_driver.get_with_nonstrict_prefix(record)
 
     return flask.jsonify(ret), 200
 

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -717,7 +717,7 @@ def get_bundle_record_with_id(bundle_id):
 
     expand = True if flask.request.args.get("expand") == "true" else False
 
-    ret = blueprint.index_driver.get(bundle_id)
+    ret = blueprint.index_driver.get_with_nonstrict_prefix(bundle_id)
 
     ret = bundle_to_drs(ret, expand=expand, is_content=False)
 

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1,6 +1,7 @@
 import datetime
 import uuid
 import json
+import re
 from contextlib import contextmanager
 from cdislogging import get_logger
 from sqlalchemy import (
@@ -1108,7 +1109,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             record = self.get(did, expand=expand)
         except NoRecordFound as e:
             DEFAULT_PREFIX = self.config.get("DEFAULT_PREFIX")
-            match = re.match(r"(dg\.[0-9a-f]{4}\/)(.+)", object_id)
+            match = re.match(r"(dg\.[0-9a-f]{4}\/)(.+)", did)
             if match and match.group(1) == DEFAULT_PREFIX:
                 record = self.get(match.group(2), expand=expand)
             elif match is None:
@@ -1116,7 +1117,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             else:
                 raise e
 
-        return ret
+        return record
 
     def update(self, did, rev, changing_fields):
         """

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1107,14 +1107,17 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             record = self.get(did, expand=expand)
         except NoRecordFound as e:
             DEFAULT_PREFIX = self.config.get("DEFAULT_PREFIX")
-            if "/" in did:
-                prefix, uuid = did.rsplit("/", 1)
-                if prefix + "/" == DEFAULT_PREFIX:
-                    record = self.get(uuid, expand=expand)
+            if DEFAULT_PREFIX is not None:
+                if "/" in did:
+                    prefix, uuid = did.rsplit("/", 1)
+                    if prefix + "/" == DEFAULT_PREFIX:
+                        record = self.get(uuid, expand=expand)
+                    else:
+                        raise e
                 else:
-                    raise e
+                    record = self.get(DEFAULT_PREFIX + did, expand=expand)
             else:
-                record = self.get(DEFAULT_PREFIX + did, expand=expand)
+                raise e
 
         return record
 

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1,7 +1,6 @@
 import datetime
 import uuid
 import json
-import re
 from contextlib import contextmanager
 from cdislogging import get_logger
 from sqlalchemy import (
@@ -1105,17 +1104,17 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         If not found and id has no prefix, attempt with default prefix prepended.
         """
         try:
-            # Try to resolve id as provided
             record = self.get(did, expand=expand)
         except NoRecordFound as e:
             DEFAULT_PREFIX = self.config.get("DEFAULT_PREFIX")
-            match = re.match(r"(dg\.[0-9a-f]{4}\/)(.+)", did)
-            if match and match.group(1) == DEFAULT_PREFIX:
-                record = self.get(match.group(2), expand=expand)
-            elif match is None:
-                record = self.get(DEFAULT_PREFIX + did, expand=expand)
+            if "/" in did:
+                prefix, uuid = did.rsplit("/", 1)
+                if prefix + "/" == DEFAULT_PREFIX:
+                    record = self.get(uuid, expand=expand)
+                else:
+                    raise e
             else:
-                raise e
+                record = self.get(DEFAULT_PREFIX + did, expand=expand)
 
         return record
 

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1107,17 +1107,17 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             record = self.get(did, expand=expand)
         except NoRecordFound as e:
             DEFAULT_PREFIX = self.config.get("DEFAULT_PREFIX")
-            if DEFAULT_PREFIX is not None:
-                if "/" in did:
-                    prefix, uuid = did.rsplit("/", 1)
-                    if prefix + "/" == DEFAULT_PREFIX:
-                        record = self.get(uuid, expand=expand)
-                    else:
-                        raise e
-                else:
-                    record = self.get(DEFAULT_PREFIX + did, expand=expand)
-            else:
+            if not DEFAULT_PREFIX:
                 raise e
+
+            if "/" in did:
+                prefix, uuid = did.rsplit("/", 1)
+                if prefix + "/" == DEFAULT_PREFIX:
+                    record = self.get(uuid, expand=expand)
+                else:
+                    raise e
+            else:
+                record = self.get(DEFAULT_PREFIX + did, expand=expand)
 
         return record
 

--- a/tests/test_driver_alchemy_crud.py
+++ b/tests/test_driver_alchemy_crud.py
@@ -632,6 +632,24 @@ def test_driver_nonstrict_get_with_incorrect_prefix():
 
 
 @util.removes("index.sq3")
+def test_driver_nonstrict_get_with_no_default_prefix():
+    """
+    Tests retrieval of a record fails as expected if no default prefix is set
+    """
+    driver = SQLAlchemyIndexDriver(
+        "sqlite:///index.sq3",
+        index_config={
+            "DEFAULT_PREFIX": None,
+            "PREPEND_PREFIX": False,
+            "ADD_PREFIX_ALIAS": False,
+        },
+    )
+
+    with pytest.raises(NoRecordFound):
+        driver.get_with_nonstrict_prefix("fake_id_without_prefix")
+
+
+@util.removes("index.sq3")
 def test_driver_get_latest_version():
     """
     Tests retrieval of the lattest record version

--- a/tests/test_driver_alchemy_crud.py
+++ b/tests/test_driver_alchemy_crud.py
@@ -531,7 +531,7 @@ def test_driver_nonstrict_get_without_prefix():
         record = driver.get_with_nonstrict_prefix(did)
 
         assert record["did"] == "testprefix/" + did, "record id does not match"
-        assert record["baseid"] == baseid, "record id does not match"
+        assert record["baseid"] == baseid, "record baseid does not match"
         assert record["rev"] == rev, "record revision does not match"
         assert record["size"] == size, "record size does not match"
         assert record["form"] == form, "record form does not match"
@@ -581,7 +581,7 @@ def test_driver_nonstrict_get_with_prefix():
         record = driver.get_with_nonstrict_prefix("testprefix/" + did)
 
         assert record["did"] == did, "record id does not match"
-        assert record["baseid"] == baseid, "record id does not match"
+        assert record["baseid"] == baseid, "record baseid does not match"
         assert record["rev"] == rev, "record revision does not match"
         assert record["size"] == size, "record size does not match"
         assert record["form"] == form, "record form does not match"


### PR DESCRIPTION
Jira Ticket: [PXP-6604](https://ctds-planx.atlassian.net/browse/PXP-6604)

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

 Now when attempting to GET a record for a specified GUID, the following resolution steps will be taken:

1. Start by trying to resolve the provided ID
2. If unsuccessful, check what the `DEFAULT_PREFIX` Indexd config is set to
3. If the ID starts with the prefix, attempt to remove the prefix from the provided ID and try resolving again
4. If the ID does not start with the prefix, attempt to add the prefix to the provided ID and try resolving again

### New Features

- Added new `get_with_nonstrict_prefix` helper to `index_driver`.
- Updated `/ga4gh/drs/v1/objects/<path:object_id>` and `/index/<path:object_id>` GET endpoints to utilize this new method.
