### PR TITLE
(PXP-7008): fix overwriting of acl and authz fields to [] on POST to /index/blank/{guid}

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-10-19T20:12:59Z",
+  "generated_at": "2020-10-30T15:26:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -122,67 +122,67 @@
       {
         "hashed_secret": "1b0d1a618b5c213dd792bbc3aa96ffa6bc370ef3",
         "is_verified": false,
-        "line_number": 1298,
+        "line_number": 1301,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "1170ace44158ff189902ff44597efef121623353",
         "is_verified": false,
-        "line_number": 1711,
+        "line_number": 1714,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "15a6d8daad1278efcaadc0d6e3d1dd2d9ebbc262",
         "is_verified": false,
-        "line_number": 2085,
+        "line_number": 2088,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "ff9c79b737b3ea7386618cc9437d3fb0a772182b",
         "is_verified": false,
-        "line_number": 2375,
+        "line_number": 2378,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "c8176f1e75e62e15dabaa4087fb7194451c8f6d2",
         "is_verified": false,
-        "line_number": 2378,
+        "line_number": 2381,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "d5198f8eddb1cbeb437899cd99e5ee97ab8531b4",
         "is_verified": false,
-        "line_number": 2378,
+        "line_number": 2381,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "02dc196562514eaa3e2feac1f441ccf6ad81e09d",
         "is_verified": false,
-        "line_number": 2382,
+        "line_number": 2385,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "f1cb2d91a95165a2ab909eadd9f7b65f312c7e2d",
         "is_verified": false,
-        "line_number": 2383,
+        "line_number": 2386,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "58db546de03270b55a4c889a5c5e6296b29fef25",
         "is_verified": false,
-        "line_number": 2384,
+        "line_number": 2387,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "b6c0bd08fde409c18760f32bef8705191840c402",
         "is_verified": false,
-        "line_number": 2385,
+        "line_number": 2388,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "5666c088b494f26cd8f63ace013992f5fc391ce0",
         "is_verified": false,
-        "line_number": 2494,
+        "line_number": 2497,
         "type": "Hex High Entropy String"
       }
     ],

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1369,15 +1369,16 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             new_record.file_name = file_name
             new_record.uploader = uploader
 
-            if authz:
-                new_record.acl = []
-                new_record.authz = [
-                    IndexRecordAuthz(did=did, resource=resource)
-                    for resource in set(authz)
+            new_record.acl = []
+            if not authz:
+                authz = old_authz
+                old_acl = [u.ace for u in old_record.acl]
+                new_record.acl = [
+                    IndexRecordACE(did=did, ace=ace) for ace in set(old_acl)
                 ]
-            else:
-                new_record.acl = old_record.acl
-                new_record.authz = old_record.authz
+            new_record.authz = [
+                IndexRecordAuthz(did=did, resource=resource) for resource in set(authz)
+            ]
 
             try:
                 session.add(new_record)


### PR DESCRIPTION
Jira Ticket: [PXP-7008](https://ctds-planx.atlassian.net/browse/PXP-7008)

Fix overwriting of `acl` and `authz` fields to `[]` on `POST` to `/index/blank/{guid}`.

### Bug Fixes
- fix overwriting of `acl` and `authz` fields to `[]` on `POST` to `/index/blank/{guid}`