### PR TITLE
chore(indexd): Utilize legacy-resolver to unblock indexd img builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /$appname
 
 RUN python -m pip install --upgrade pip \
     && python -m pip install --upgrade setuptools \
-    && pip install -r requirements.txt
+    && pip install -r requirements.txt --use-deprecated=legacy-resolver
 
 RUN mkdir -p /var/www/$appname \
     && mkdir -p /var/www/.cache/Python-Eggs/ \


### PR DESCRIPTION
Unblocking release202101 by avoiding a timeout in our indexd Docker build, which is caused by the following operation in Quay:
```
12/16/2020, 5:07:10 PMINFO: pip is looking at multiple versions of psycopg2 to determine 
which version is compatible with other requirements. This could take a while.
12/16/2020, 5:07:10 PMCollecting psycopg2>=2.7 
```

### Improvements
- Use `--use-deprecated=legacy-resolver` to avoid issues with the latest pip (>=20.3).