### PR TITLE
Bundles: don't swallow exception + Old indexd_admin deprecation log

### DIFF
--- a/indexd/alias/drivers/alchemy.py
+++ b/indexd/alias/drivers/alchemy.py
@@ -130,7 +130,7 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
         try:
             yield session
             session.commit()
-        except:
+        except Exception:
             session.rollback()
             raise
         finally:

--- a/indexd/auth/drivers/alchemy.py
+++ b/indexd/auth/drivers/alchemy.py
@@ -61,7 +61,7 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
         try:
             yield session
             session.commit()
-        except:
+        except Exception:
             session.rollback()
             raise
         finally:

--- a/indexd/auth/drivers/alchemy.py
+++ b/indexd/auth/drivers/alchemy.py
@@ -153,6 +153,10 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
                     is_admin = self.arborist.auth_request(
                         get_jwt_token(), "indexd", method, ["/programs"]
                     )
+                    if is_admin:
+                        logger.warning(
+                            "The indexd admin '/programs' logic is deprecated. Please update your policy to '/services/indexd/admin'"
+                        )
                 if not is_admin:
                     raise AuthError("Permission denied.")
         except Exception as err:

--- a/indexd/blueprint.py
+++ b/indexd/blueprint.py
@@ -87,7 +87,7 @@ def dist_get_record(record):
             else:
                 fetcher_client = IndexClient(baseurl=indexd["host"])
                 res = fetcher_client.global_get(record, no_dist=True)
-        except:
+        except Exception:
             # a lot of things can go wrong with the get, but in general we don't care here.
             continue
 

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -5,7 +5,7 @@ import hashlib
 import jsonschema
 from .version_data import VERSION, COMMIT
 
-from indexd.auth import authorize
+from indexd import auth
 
 from indexd.errors import AuthError, AuthzError
 from indexd.errors import UserError
@@ -263,7 +263,7 @@ def post_index_record():
         raise UserError(err)
 
     authz = flask.request.json.get("authz", [])
-    authorize("create", authz)
+    auth.authorize("create", authz)
 
     did = flask.request.json.get("did")
     form = flask.request.json["form"]
@@ -644,11 +644,7 @@ def post_bundle():
     """
     Create a new bundle
     """
-
-    try:
-        authorize("create", ["/services/indexd/bundles"])
-    except:
-        raise AuthError("Invalid Token.")
+    auth.authorize("create", ["/services/indexd/bundles"])
     try:
         jsonschema.validate(flask.request.json, BUNDLE_SCHEMA)
     except jsonschema.ValidationError as err:
@@ -751,10 +747,7 @@ def delete_bundle_record(bundle_id):
     """
     Delete bundle record given bundle_id
     """
-    try:
-        authorize("delete", ["/services/indexd/bundles"])
-    except:
-        raise AuthError("Invalid Token.")
+    auth.authorize("delete", ["/services/indexd/bundles"])
     blueprint.index_driver.delete_bundle(bundle_id)
 
     return "", 200

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -358,7 +358,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         try:
             yield session
             session.commit()
-        except:
+        except Exception:
             session.rollback()
             raise
         finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,7 @@ def app():
     yield get_app(default_test_settings.settings)
     try:
         clear_database()
-
-    except:
+    except Exception:
         pass
 
 


### PR DESCRIPTION


### Improvements
- Bundles endpoints: don't swallow authorization exceptions
- Add a deprecation log to the old "indexd_admin" logic
