### PR TITLE
chore(pybase3): Update pybase img de novo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To run: docker run -v /path/to/wsgi.py:/var/www/indexd/wsgi.py --name=indexd -p 81:80 indexd
 # To check running container: docker exec -it indexd /bin/bash
 
-FROM quay.io/cdis/python-nginx:pybase3-1.5.0
+FROM quay.io/cdis/python-nginx:pybase3-1.6.1
 
 
 ENV appname=indexd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexd"
-version = "2.15.0"
+version = "3.1.1"
 description = "Gen3 Indexing Service"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Suppressing UWSGI & NGINX metrics in favour of DataDog’s telemetry / python APM / probing -- hoping we can achieve the same observability with it.

Once we retire the k8s sidecar containers from indexd's k8s YAML (here: https://github.com/uc-cdis/cloud-automation/pull/1643), old indexd images will face a lot of log noise as the HTTP metrics endpoints will no longer exist.
