### PR TITLE
PXP-9190: Remove Contents from DRS blobs

### DIFF
--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -168,7 +168,6 @@ def indexd_to_drs(record, expand=False):
         "updated_time": updated_date,
         "size": record["size"],
         "aliases": alias,
-        "contents": [],
         "self_uri": self_uri,
         "version": version,
         "form": form,
@@ -179,11 +178,13 @@ def indexd_to_drs(record, expand=False):
     if "description" in record:
         drs_object["description"] = record["description"]
 
-    for bundle in record.get("bundle_data", []):
-        bundle_object = bundle_to_drs(bundle, expand=expand, is_content=True)
-        if not expand:
-            bundle_object.pop("contents", None)
-        drs_object["contents"].append(bundle_object)
+    if "bundle_data" in record:
+        drs_object["contents"] = []
+        for bundle in record.get("bundle_data", []):
+            bundle_object = bundle_to_drs(bundle, expand=expand, is_content=True)
+            if not expand:
+                bundle_object.pop("contents", None)
+            drs_object["contents"].append(bundle_object)
 
     # access_methods mapping
     if "urls" in record:

--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -180,7 +180,7 @@ def indexd_to_drs(record, expand=False):
 
     if "bundle_data" in record:
         drs_object["contents"] = []
-        for bundle in record.get("bundle_data", []):
+        for bundle in record["bundle_data"]:
             bundle_object = bundle_to_drs(bundle, expand=expand, is_content=True)
             if not expand:
                 bundle_object.pop("contents", None)

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -57,6 +57,7 @@ def test_drs_get(client, user):
         assert rec_2["checksums"][0]["type"] == k
     assert rec_2["version"]
     assert rec_2["self_uri"] == "drs://testprefix:" + rec_1["did"].split(":")[1]
+    assert "contents" not in rec_2
 
 
 def test_drs_get_no_default(client, user):

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -57,6 +57,7 @@ def test_drs_get(client, user):
         assert rec_2["checksums"][0]["type"] == k
     assert rec_2["version"]
     assert rec_2["self_uri"] == "drs://testprefix:" + rec_1["did"].split(":")[1]
+    # according to ga4gh DRS blobs objects are NOT supposed to have contents. Only DRS Bundle objects should include the contetnts field
     assert "contents" not in rec_2
 
 


### PR DESCRIPTION
### Bug Fixes
- Remove `contents` field from DRS Blob objects

