### PR TITLE
add uwsgi listen queue

### DIFF
--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -33,3 +33,5 @@ exec-asap = /indexd/clear_prometheus_multiproc /var/tmp/uwsgi_flask_metrics
 # workers from all trying to open the same database connections at startup.
 lazy = true
 lazy-apps = true
+listen=4096
+processes = 8

--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -33,4 +33,4 @@ exec-asap = /indexd/clear_prometheus_multiproc /var/tmp/uwsgi_flask_metrics
 # workers from all trying to open the same database connections at startup.
 lazy = true
 lazy-apps = true
-listen = 8192
+listen = 4096

--- a/deployment/uwsgi/uwsgi.ini
+++ b/deployment/uwsgi/uwsgi.ini
@@ -33,5 +33,4 @@ exec-asap = /indexd/clear_prometheus_multiproc /var/tmp/uwsgi_flask_metrics
 # workers from all trying to open the same database connections at startup.
 lazy = true
 lazy-apps = true
-listen=4096
-processes = 8
+listen = 8192


### PR DESCRIPTION
### New Features
Adding listen queue to uwsgi config. We were seeing issues with large instances of indexd (100M) on a large amount of `GET` requests we had a 1.5% failure rate. Adding a listen queue solved this.