### PR TITLE
Update error message

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-09-30T18:17:02Z",
+  "generated_at": "2022-09-06T17:03:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -62,7 +62,7 @@
       {
         "hashed_secret": "8c0fdc72bf4daf2a2338287334d0cbd221fa9ef4",
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 27,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ jdk:
     - oraclejdk8
 
 install:
-    - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-    - source $HOME/.poetry/env
+    - pip install poetry
     - poetry install -vv
 
 

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1108,10 +1108,11 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             record = query.first()
             if record is None:
-                record = self.get_bundle(bundle_id=did, expand=expand)
-                if record:
+                try:
+                    record = self.get_bundle(bundle_id=did, expand=expand)
                     return record
-                else:
+                except NoRecordFound:
+                    # overwrite the "no bundle found" message
                     raise NoRecordFound("no record found")
 
             return record.to_document_dict()
@@ -1196,7 +1197,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             # authorization check: `update` access on old AND new resources
             try:
                 auth.authorize("update", all_authz)
-            except AuthError as err:
+            except AuthError:
                 self.logger.error(authz_err_msg.format("update", all_authz))
                 raise
 


### PR DESCRIPTION
indexd's GET endpoint checks if a record exists and if not, if a bundle exists. If neither exist, we currently return the error message "no bundle found" that comes from `get_bundle()`. We should return "no record found" instead since this endpoint is not specific to bundles

### Improvements
- Update `GET /index/<GUID>` error message
