### PR TITLE
PXP-10714: Prefer version to rev

### DIFF
--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -116,10 +116,10 @@ def indexd_to_drs(record, expand=False):
     )
 
     version = (
-        record["rev"]
-        if "rev" in record
-        else record["version"]
+        record["version"]
         if "version" in record
+        else record["rev"]
+        if "rev" in record
         else ""
     )
 
@@ -240,7 +240,14 @@ def bundle_to_drs(record, expand=False, is_content=False):
             if "aliases" in record
             else []
         )
-        version = record["version"] if "version" in record else ""
+        version = (
+            record["version"]
+            if "version" in record
+            else record["rev"]
+            if "rev" in record
+            else ""
+        )
+        # version = record["version"] if "version" in record else ""
         drs_object["checksums"] = parse_checksums(record, drs_object)
 
         created_time = (


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->
Currently the DRS response version prefers indexd rev instead of version.
This prefers version before rev. If version is not available it should fallback to rev.

### New Features


### Breaking Changes


### Bug Fixes
- DRS response prefers version before rev, if version is not available it uses rev

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
