### PR TITLE
feat(DCF-450): Add DRS Fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ docs/_build/
 local_settings.py
 settings.yaml
 *.sq3
+#IDEs
+.idea

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -224,6 +224,15 @@
         "line_number": 14
       }
     ],
+    "migrations/versions/a72f117515c5_add_description_created_time_and_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/a72f117515c5_add_description_created_time_and_.py",
+        "hashed_secret": "7c52f05d2823f0becb8196c04678c822ac71bcdf",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
     "tests/default_test_settings.py": [
       {
         "type": "Basic Auth Credentials",
@@ -240,6 +249,15 @@
         "hashed_secret": "7c52f05d2823f0becb8196c04678c822ac71bcdf",
         "is_verified": false,
         "line_number": 18
+      }
+    ],
+    "tests/postgres/migrations/test_a72f117515c5_add_description_created_time_and_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/postgres/migrations/test_a72f117515c5_add_description_created_time_and_.py",
+        "hashed_secret": "7c52f05d2823f0becb8196c04678c822ac71bcdf",
+        "is_verified": false,
+        "line_number": 31
       }
     ],
     "tests/postgres/migrations/test_legacy_schema_migration.py": [
@@ -382,7 +400,7 @@
         "filename": "tests/test_deprecated_aliases_endpoints.py",
         "hashed_secret": "5666c088b494f26cd8f63ace013992f5fc391ce0",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 13
       }
     ],
     "tests/test_drs.py": [
@@ -391,9 +409,9 @@
         "filename": "tests/test_drs.py",
         "hashed_secret": "5666c088b494f26cd8f63ace013992f5fc391ce0",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 38
       }
     ]
   },
-  "generated_at": "2023-04-13T17:00:13Z"
+  "generated_at": "2023-04-19T18:14:25Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -257,7 +257,7 @@
         "filename": "tests/postgres/migrations/test_a72f117515c5_add_description_created_time_and_.py",
         "hashed_secret": "7c52f05d2823f0becb8196c04678c822ac71bcdf",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 21
       }
     ],
     "tests/postgres/migrations/test_legacy_schema_migration.py": [
@@ -413,5 +413,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-19T18:14:25Z"
+  "generated_at": "2023-04-20T22:58:41Z"
 }

--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -150,7 +150,7 @@ def indexd_to_drs(record, expand=False):
 
     name = record["file_name"] if "file_name" in record else record["name"]
 
-    created_time = (
+    index_created_time = (
         record["created_date"] if "created_date" in record else record["created_time"]
     )
 
@@ -162,9 +162,13 @@ def indexd_to_drs(record, expand=False):
         else ""
     )
 
-    updated_date = (
+    index_updated_time = (
         record["updated_date"] if "updated_date" in record else record["updated_time"]
     )
+
+    created_time = record.get("content_created_date", "")
+
+    updated_time = record.get("content_updated_date", "")
 
     form = record["form"] if "form" in record else "bundle"
 
@@ -180,11 +184,12 @@ def indexd_to_drs(record, expand=False):
 
     drs_object = {
         "id": did,
-        "description": "",
         "mime_type": "application/json",
         "name": name,
+        "index_created_time": index_created_time,
+        "index_updated_time": index_updated_time,
         "created_time": created_time,
-        "updated_time": updated_date,
+        "updated_time": updated_time,
         "size": record["size"],
         "aliases": alias,
         "self_uri": self_uri,

--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -166,9 +166,9 @@ def indexd_to_drs(record, expand=False):
         record["updated_date"] if "updated_date" in record else record["updated_time"]
     )
 
-    created_time = record.get("content_created_date", "")
+    content_created_date = record.get("content_created_date", "")
 
-    updated_time = record.get("content_updated_date", "")
+    content_updated_date = record.get("content_updated_date", "")
 
     form = record["form"] if "form" in record else "bundle"
 
@@ -188,8 +188,8 @@ def indexd_to_drs(record, expand=False):
         "name": name,
         "index_created_time": index_created_time,
         "index_updated_time": index_updated_time,
-        "created_time": created_time,
-        "updated_time": updated_time,
+        "created_time": content_created_date,
+        "updated_time": content_updated_date,
         "size": record["size"],
         "aliases": alias,
         "self_uri": self_uri,

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -408,8 +408,8 @@ def post_index_record():
     baseid = flask.request.json.get("baseid")
     uploader = flask.request.json.get("uploader")
     description = flask.request.json.get("description")
-    content_created_date = flask.request.json.get("created_time")
-    content_updated_date = flask.request.json.get("updated_time")
+    content_created_date = flask.request.json.get("content_created_date")
+    content_updated_date = flask.request.json.get("content_updated_date")
 
     if content_updated_date is None:
         content_updated_date = content_created_date
@@ -525,8 +525,8 @@ def put_index_record(record):
 
     rev = flask.request.args.get("rev")
     json = flask.request.json
-    if "updated_time" in json and "created_time" in json:
-        if json["updated_time"] < json["created_time"]:
+    if "content_updated_date" in json and "content_created_date" in json:
+        if json["content_updated_date"] < json["content_created_date"]:
             raise UserError("updated_time cannot come before created_date")
 
     # authorize done in update
@@ -574,8 +574,8 @@ def add_index_record_version(record):
     urls_metadata = flask.request.json.get("urls_metadata")
     version = flask.request.json.get("version")
     description = flask.request.json.get("description")
-    content_created_date = flask.request.json.get("created_time")
-    content_updated_date = flask.request.json.get("updated_time")
+    content_created_date = flask.request.json.get("content_created_date")
+    content_updated_date = flask.request.json.get("content_updated_date")
 
     if content_updated_date is None:
         content_updated_date = content_created_date

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -415,11 +415,13 @@ def post_index_record():
         content_updated_date = content_created_date
 
     if content_updated_date is not None and content_created_date is None:
-        raise UserError("Cannot set updated_time without created_time")
+        raise UserError("Cannot set content_updated_date without content_created_date")
 
     if content_updated_date is not None and content_created_date is not None:
         if content_updated_date < content_created_date:
-            raise UserError("updated_time cannot come before created_date")
+            raise UserError(
+                "content_updated_date cannot come before content_created_date"
+            )
 
     did, rev, baseid = blueprint.index_driver.add(
         form,
@@ -527,7 +529,9 @@ def put_index_record(record):
     json = flask.request.json
     if "content_updated_date" in json and "content_created_date" in json:
         if json["content_updated_date"] < json["content_created_date"]:
-            raise UserError("updated_time cannot come before created_date")
+            raise UserError(
+                "content_updated_date cannot come before content_created_date"
+            )
 
     # authorize done in update
     did, baseid, rev = blueprint.index_driver.update(record, rev, json)
@@ -582,7 +586,9 @@ def add_index_record_version(record):
 
     if content_updated_date is not None and content_created_date is not None:
         if content_updated_date < content_created_date:
-            raise UserError("updated_time cannot come before created_date")
+            raise UserError(
+                "content_updated_date cannot come before content_created_date"
+            )
 
     # authorize done in add_version for both the old and new authz
     did, baseid, rev = blueprint.index_driver.add_version(

--- a/indexd/index/driver.py
+++ b/indexd/index/driver.py
@@ -58,6 +58,9 @@ class IndexDriverABC(SQLAlchemyDriverBase, metaclass=abc.ABCMeta):
         hashes=None,
         baseid=None,
         uploader=None,
+        description=None,
+        content_created_date=None,
+        content_updated_date=None,
     ):
         """
         Creates record for given data.
@@ -100,6 +103,9 @@ class IndexDriverABC(SQLAlchemyDriverBase, metaclass=abc.ABCMeta):
         acl=None,
         authz=None,
         hashes=None,
+        description=None,
+        created_time=None,
+        updated_time=None,
     ):
         """
         Add a record version given did

--- a/indexd/index/driver.py
+++ b/indexd/index/driver.py
@@ -104,8 +104,8 @@ class IndexDriverABC(SQLAlchemyDriverBase, metaclass=abc.ABCMeta):
         authz=None,
         hashes=None,
         description=None,
-        created_time=None,
-        updated_time=None,
+        content_created_date=None,
+        content_updated_date=None,
     ):
         """
         Add a record version given did

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1176,8 +1176,8 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             "authz",
             "metadata",
             "urls_metadata",
-            "created_time",
-            "updated_time",
+            "content_created_date",
+            "content_updated_date",
         ]
 
         with self.session as session:
@@ -1250,17 +1250,17 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
                 create_urls_metadata(changing_fields["urls_metadata"], record, session)
 
-            if "created_time" in changing_fields:
+            if "content_created_date" in changing_fields:
                 record.content_created_date = datetime.datetime.fromisoformat(
-                    changing_fields["created_time"]
+                    changing_fields["content_created_date"]
                 )
-            if "updated_time" in changing_fields:
+            if "content_updated_date" in changing_fields:
                 if record.content_created_date is None:
                     raise UserError(
                         "Cannot set updated_time on record that does not have a created_time"
                     )
                 record.content_updated_date = datetime.datetime.fromisoformat(
-                    changing_fields["updated_time"]
+                    changing_fields["content_updated_date"]
                 )
 
             for key, value in changing_fields.items():

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -1257,8 +1257,15 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             if "content_updated_date" in changing_fields:
                 if record.content_created_date is None:
                     raise UserError(
-                        "Cannot set updated_time on record that does not have a created_time"
+                        "Cannot set content_updated_date on record that does not have a content_created_date"
                     )
+                if record.content_created_date > datetime.datetime.fromisoformat(
+                    changing_fields["content_updated_date"]
+                ):
+                    raise UserError(
+                        "Cannot set content_updated_date before the content_created_date"
+                    )
+
                 record.content_updated_date = datetime.datetime.fromisoformat(
                     changing_fields["content_updated_date"]
                 )

--- a/indexd/index/schema.py
+++ b/indexd/index/schema.py
@@ -31,6 +31,10 @@ POST_RECORD_SCHEMA = {
             "description": "optional version string of the object",
             "type": "string",
         },
+        "description": {
+            "description": "optional description string of the object",
+            "type": "string",
+        },
         "uploader": {
             "description": "optional uploader of the object",
             "type": "string",
@@ -45,6 +49,16 @@ POST_RECORD_SCHEMA = {
         "did": {
             "type": "string",
             "pattern": "^.*[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        },
+        "created_time": {
+            "description": "Timestamp of content creation. Refers to the underyling content, not the JSON object.",
+            "type": "string",
+            "format": "date-time",
+        },
+        "updated_time": {
+            "description": "Timestamp of content update, identical to created_time in systems that do not support updates. Refers to the underyling content, not the JSON object.",
+            "type": "string",
+            "format": "date-time",
         },
         "hashes": {
             "type": "object",
@@ -82,6 +96,9 @@ PUT_RECORD_SCHEMA = {
         "uploader": {"type": ["string", "null"]},
         "metadata": {"type": "object"},
         "urls_metadata": {"type": "object"},
+        "description": {"type": ["string", "null"]},
+        "created_time": {"type": ["string", "null"], "format": "date-time"},
+        "updated_time": {"type": ["string", "null"], "format": "date-time"},
     },
 }
 

--- a/indexd/index/schema.py
+++ b/indexd/index/schema.py
@@ -50,12 +50,12 @@ POST_RECORD_SCHEMA = {
             "type": "string",
             "pattern": "^.*[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
         },
-        "created_time": {
+        "content_created_date": {
             "description": "Timestamp of content creation. Refers to the underyling content, not the JSON object.",
             "type": "string",
             "format": "date-time",
         },
-        "updated_time": {
+        "content_updated_date": {
             "description": "Timestamp of content update, identical to created_time in systems that do not support updates. Refers to the underyling content, not the JSON object.",
             "type": "string",
             "format": "date-time",
@@ -97,8 +97,8 @@ PUT_RECORD_SCHEMA = {
         "metadata": {"type": "object"},
         "urls_metadata": {"type": "object"},
         "description": {"type": ["string", "null"]},
-        "created_time": {"type": ["string", "null"], "format": "date-time"},
-        "updated_time": {"type": ["string", "null"], "format": "date-time"},
+        "content_created_date": {"type": ["string", "null"], "format": "date-time"},
+        "content_updated_date": {"type": ["string", "null"], "format": "date-time"},
     },
 }
 

--- a/migrations/versions/a72f117515c5_add_description_created_time_and_.py
+++ b/migrations/versions/a72f117515c5_add_description_created_time_and_.py
@@ -1,4 +1,4 @@
-"""Add description, created_time and updated_time columns to IndexRecord
+"""Add description, content_created_date and content_updated_date columns to IndexRecord
 
 Revision ID: a72f117515c5
 Revises: 15f2e9345ade

--- a/migrations/versions/a72f117515c5_add_description_created_time_and_.py
+++ b/migrations/versions/a72f117515c5_add_description_created_time_and_.py
@@ -1,0 +1,32 @@
+"""Add description, created_time and updated_time columns to IndexRecord
+
+Revision ID: a72f117515c5
+Revises: 15f2e9345ade
+Create Date: 2023-04-11 10:00:59.250768
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a72f117515c5"
+down_revision = "15f2e9345ade"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "index_record", sa.Column("content_created_date", sa.DateTime, nullable=True)
+    )
+    op.add_column(
+        "index_record", sa.Column("content_updated_date", sa.DateTime, nullable=True)
+    )
+    op.add_column("index_record", sa.Column("description", sa.VARCHAR(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("index_record", "content_created_date")
+    op.drop_column("index_record", "content_updated_date")
+    op.drop_column("index_record", "description")

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -2350,7 +2350,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Checksum'
-
       bundles:
         type: array
         items:

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -1463,6 +1463,17 @@ definitions:
           type: string
       hashes:
         $ref: '#/definitions/HashInfo'
+      description:
+        type: string
+        description: optional description of the object
+      content_created_date:
+        type: string
+        format: date-time
+        description: optional creation date and time of the content being indexed
+      content_updated_date:
+        type: string
+        format: date-time
+        description: optional creation date and time of the content being indexed
   BulkInputInfo:
     type: array
     items:
@@ -2350,6 +2361,12 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Checksum'
+      description:
+        type: string
+        description: optional description of the object
+      version:
+        type: string
+        description: optional version string of the object
       bundles:
         type: array
         items:

--- a/tests/postgres/migrations/test_a72f117515c5_add_description_created_time_and_.py
+++ b/tests/postgres/migrations/test_a72f117515c5_add_description_created_time_and_.py
@@ -1,0 +1,48 @@
+from alembic.config import main as alembic_main
+
+
+def test_upgrade(postgres_driver):
+    conn = postgres_driver.engine.connect()
+    alembic_main(["--raiseerr", "upgrade", "a72f117515c5"])
+    cols = conn.execute(
+        "SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'index_record'"
+    )
+    expected_schema = [
+        ("did", "character varying"),
+        ("baseid", "character varying"),
+        ("rev", "character varying"),
+        ("form", "character varying"),
+        ("size", "bigint"),
+        ("created_date", "timestamp without time zone"),
+        ("updated_date", "timestamp without time zone"),
+        ("file_name", "character varying"),
+        ("version", "character varying"),
+        ("uploader", "character varying"),
+        ("description", "character varying"),
+        ("content_created_date", "timestamp without time zone"),
+        ("content_updated_date", "timestamp without time zone"),
+    ]
+    actual_schema = sorted([i for i in cols])
+    assert sorted(expected_schema) == actual_schema
+
+
+def test_downgrade(postgres_driver):
+    conn = postgres_driver.engine.connect()
+    alembic_main(["--raiseerr", "downgrade", "15f2e9345ade"])
+    cols = conn.execute(
+        "SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'index_record'"
+    )
+    expected_schema = [
+        ("did", "character varying"),
+        ("baseid", "character varying"),
+        ("rev", "character varying"),
+        ("form", "character varying"),
+        ("size", "bigint"),
+        ("created_date", "timestamp without time zone"),
+        ("updated_date", "timestamp without time zone"),
+        ("file_name", "character varying"),
+        ("version", "character varying"),
+        ("uploader", "character varying"),
+    ]
+    actual_schema = sorted([i for i in cols])
+    assert sorted(expected_schema) == actual_schema

--- a/tests/postgres/migrations/test_a72f117515c5_add_description_created_time_and_.py
+++ b/tests/postgres/migrations/test_a72f117515c5_add_description_created_time_and_.py
@@ -3,10 +3,8 @@ from alembic.config import main as alembic_main
 
 def test_upgrade(postgres_driver):
     conn = postgres_driver.engine.connect()
-    alembic_main(["--raiseerr", "upgrade", "a72f117515c5"])
-    cols = conn.execute(
-        "SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'index_record'"
-    )
+    get_columns = "SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'index_record'"
+
     expected_schema = [
         ("did", "character varying"),
         ("baseid", "character varying"),
@@ -18,10 +16,22 @@ def test_upgrade(postgres_driver):
         ("file_name", "character varying"),
         ("version", "character varying"),
         ("uploader", "character varying"),
+    ]
+
+    alembic_main(["--raiseerr", "downgrade", "15f2e9345ade"])
+    cols = conn.execute(get_columns)
+    actual_schema = sorted([i for i in cols])
+    assert sorted(expected_schema) == actual_schema
+
+    alembic_main(["--raiseerr", "upgrade", "a72f117515c5"])
+    cols = conn.execute(get_columns)
+
+    expected_schema += [
         ("description", "character varying"),
         ("content_created_date", "timestamp without time zone"),
         ("content_updated_date", "timestamp without time zone"),
     ]
+
     actual_schema = sorted([i for i in cols])
     assert sorted(expected_schema) == actual_schema
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2646,3 +2646,56 @@ def test_get_dist(client):
             "type": "indexd",
         }
     ]
+
+
+def test_changing_timestamps_updated_not_before_created(client, user):
+    data = get_doc()
+    data["content_updated_date"] = "2023-03-14T17:02:54"
+    data["content_created_date"] = "2023-03-13T17:02:54"
+    create_obj_resp = client.post("/index/", json=data, headers=user)
+    assert create_obj_resp.status_code == 200
+    obj_did = create_obj_resp.json["did"]
+    obj_rev = create_obj_resp.json["rev"]
+    update_json = {
+        "content_created_date": "2023-03-15T17:02:54",
+        "content_updated_date": "2022-03-30T17:02:54",
+    }
+    update_obj_resp = client.put(
+        f"/index/{obj_did}?rev={obj_rev}", json=update_json, headers=user
+    )
+    assert update_obj_resp.status_code == 400
+    update_json = {
+        "content_updated_date": "2022-03-30T17:02:54",
+    }
+    update_obj_resp = client.put(
+        f"/index/{obj_did}?rev={obj_rev}", json=update_json, headers=user
+    )
+    assert update_obj_resp.status_code == 400
+
+
+def test_changing_timestamps_no_updated_without_created(client, user):
+    data = get_doc()
+    create_obj_resp = client.post("/index/", json=data, headers=user)
+    assert create_obj_resp.status_code == 200
+    obj_did = create_obj_resp.json["did"]
+    obj_rev = create_obj_resp.json["rev"]
+    update_json = {"content_updated_date": "2022-03-30T17:02:54"}
+    update_obj_resp = client.put(
+        f"/index/{obj_did}?rev={obj_rev}", json=update_json, headers=user
+    )
+    assert update_obj_resp.status_code == 400
+
+
+def test_timestamps_updated_not_before_created(client, user):
+    data = get_doc()
+    data["content_created_date"] = "2023-03-13T17:02:54"
+    data["content_updated_date"] = "2022-03-14T17:02:54"
+    create_obj_resp = client.post("/index/", json=data, headers=user)
+    assert create_obj_resp.status_code == 400
+
+
+def test_timestamps_no_updated_without_created(client, user):
+    data = get_doc()
+    data["content_updated_date"] = "2022-03-14T17:02:54"
+    create_obj_resp = client.post("/index/", json=data, headers=user)
+    assert create_obj_resp.status_code == 400

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2649,6 +2649,9 @@ def test_get_dist(client):
 
 
 def test_changing_timestamps_updated_not_before_created(client, user):
+    """
+    Checks that records cannot be updated to have a content_updated_date before the provided content_created_date
+    """
     data = get_doc()
     data["content_updated_date"] = "2023-03-14T17:02:54"
     data["content_created_date"] = "2023-03-13T17:02:54"
@@ -2674,6 +2677,10 @@ def test_changing_timestamps_updated_not_before_created(client, user):
 
 
 def test_changing_timestamps_no_updated_without_created(client, user):
+    """
+    Checks that records cannot be updated to have a content_updated_date when a content_created_date does not exist
+    for the record and one is not provided in the update.
+    """
     data = get_doc()
     create_obj_resp = client.post("/index/", json=data, headers=user)
     assert create_obj_resp.status_code == 200
@@ -2687,6 +2694,9 @@ def test_changing_timestamps_no_updated_without_created(client, user):
 
 
 def test_timestamps_updated_not_before_created(client, user):
+    """
+    Checks that records cannot be created with a content_update_date that is before the content_created_date
+    """
     data = get_doc()
     data["content_created_date"] = "2023-03-13T17:02:54"
     data["content_updated_date"] = "2022-03-14T17:02:54"
@@ -2695,6 +2705,9 @@ def test_timestamps_updated_not_before_created(client, user):
 
 
 def test_timestamps_no_updated_without_created(client, user):
+    """
+    Checks that records cannot be created with a content_update_date without providing a content_created_date
+    """
     data = get_doc()
     data["content_updated_date"] = "2022-03-14T17:02:54"
     create_obj_resp = client.post("/index/", json=data, headers=user)

--- a/tests/test_driver_alchemy_crud.py
+++ b/tests/test_driver_alchemy_crud.py
@@ -445,7 +445,7 @@ def test_driver_get_record():
         baseid = str(uuid.uuid4())
         created_date = datetime.now()
         updated_date = datetime.now()
-        description = ""
+        description = "a description"
         content_created_date = datetime.now()
         content_updated_date = datetime.now()
 
@@ -520,9 +520,10 @@ def test_driver_nonstrict_get_without_prefix():
         updated_date = datetime.now()
         content_created_date = datetime.now()
         content_updated_date = datetime.now()
+        description = "a description"
         conn.execute(
             """
-            INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date) VALUES (?,?,?,?,?,?,?,?,?)
+            INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date, description) VALUES (?,?,?,?,?,?,?,?,?,?)
         """,
             (
                 "testprefix/" + did,
@@ -534,6 +535,7 @@ def test_driver_nonstrict_get_without_prefix():
                 updated_date,
                 content_created_date,
                 content_updated_date,
+                description,
             ),
         )
 
@@ -578,7 +580,7 @@ def test_driver_nonstrict_get_with_prefix():
         baseid = str(uuid.uuid4())
         created_date = datetime.now()
         updated_date = datetime.now()
-        description = ""
+        description = "a description"
         content_created_date = datetime.now()
         content_updated_date = datetime.now()
         conn.execute(
@@ -688,7 +690,7 @@ def test_driver_get_latest_version():
             baseid = str(uuid.uuid4())
             created_date = datetime.now()
             updated_date = datetime.now()
-            description = ""
+            description = "a description"
             content_created_date = datetime.now()
             content_updated_date = datetime.now()
             conn.execute(
@@ -771,6 +773,7 @@ def test_driver_get_all_versions():
         updated_dates = []
         content_created_dates = []
         content_updated_dates = []
+        descriptions = []
         for _ in range(NUMBER_OF_RECORD):
             did = str(uuid.uuid4())
             rev = str(uuid.uuid4())[:8]
@@ -780,16 +783,17 @@ def test_driver_get_all_versions():
             updated_date = created_date
             content_created_date = datetime.now()
             content_updated_date = created_date
+            description = f"description for {did}"
             dids.append(did)
             revs.append(rev)
             created_dates.append(created_date)
             updated_dates.append(updated_date)
             content_created_dates.append(content_created_date)
-            content_updated_dates.append(content_updated_date)
+            descriptions.append(description)
             conn.execute(
                 """
-                INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date) \
-                    VALUES (?,?,?,?,?,?,?,?,?)
+                INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date, description) \
+                    VALUES (?,?,?,?,?,?,?,?,?,?)
             """,
                 (
                     did,
@@ -801,6 +805,7 @@ def test_driver_get_all_versions():
                     updated_date,
                     content_created_date,
                     content_updated_date,
+                    description,
                 ),
             )
 

--- a/tests/test_driver_alchemy_crud.py
+++ b/tests/test_driver_alchemy_crud.py
@@ -445,12 +445,26 @@ def test_driver_get_record():
         baseid = str(uuid.uuid4())
         created_date = datetime.now()
         updated_date = datetime.now()
+        description = ""
+        content_created_date = datetime.now()
+        content_updated_date = datetime.now()
 
         conn.execute(
             """
-            INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date) VALUES (?,?,?,?,?,?,?)
+            INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date, description) VALUES (?,?,?,?,?,?,?,?,?,?)
         """,
-            (did, baseid, rev, form, size, created_date, updated_date),
+            (
+                did,
+                baseid,
+                rev,
+                form,
+                size,
+                created_date,
+                updated_date,
+                content_created_date,
+                content_updated_date,
+                description,
+            ),
         )
 
         conn.commit()
@@ -504,12 +518,23 @@ def test_driver_nonstrict_get_without_prefix():
         baseid = str(uuid.uuid4())
         created_date = datetime.now()
         updated_date = datetime.now()
-
+        content_created_date = datetime.now()
+        content_updated_date = datetime.now()
         conn.execute(
             """
-            INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date) VALUES (?,?,?,?,?,?,?)
+            INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date) VALUES (?,?,?,?,?,?,?,?,?)
         """,
-            ("testprefix/" + did, baseid, rev, form, size, created_date, updated_date),
+            (
+                "testprefix/" + did,
+                baseid,
+                rev,
+                form,
+                size,
+                created_date,
+                updated_date,
+                content_created_date,
+                content_updated_date,
+            ),
         )
 
         conn.commit()
@@ -553,12 +578,25 @@ def test_driver_nonstrict_get_with_prefix():
         baseid = str(uuid.uuid4())
         created_date = datetime.now()
         updated_date = datetime.now()
-
+        description = ""
+        content_created_date = datetime.now()
+        content_updated_date = datetime.now()
         conn.execute(
             """
-            INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date) VALUES (?,?,?,?,?,?,?)
+            INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date, description) VALUES (?,?,?,?,?,?,?,?,?,?)
         """,
-            (did, baseid, rev, form, size, created_date, updated_date),
+            (
+                did,
+                baseid,
+                rev,
+                form,
+                size,
+                created_date,
+                updated_date,
+                content_created_date,
+                content_updated_date,
+                description,
+            ),
         )
 
         conn.commit()
@@ -650,12 +688,25 @@ def test_driver_get_latest_version():
             baseid = str(uuid.uuid4())
             created_date = datetime.now()
             updated_date = datetime.now()
-
+            description = ""
+            content_created_date = datetime.now()
+            content_updated_date = datetime.now()
             conn.execute(
                 """
-                INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date) VALUES (?,?,?,?,?,?,?)
+                INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date, description) VALUES (?,?,?,?,?,?,?,?,?,?)
             """,
-                (did, baseid, rev, form, size, created_date, updated_date),
+                (
+                    did,
+                    baseid,
+                    rev,
+                    form,
+                    size,
+                    created_date,
+                    updated_date,
+                    content_created_date,
+                    content_updated_date,
+                    description,
+                ),
             )
 
             conn.commit()
@@ -718,7 +769,8 @@ def test_driver_get_all_versions():
         revs = []
         created_dates = []
         updated_dates = []
-
+        content_created_dates = []
+        content_updated_dates = []
         for _ in range(NUMBER_OF_RECORD):
             did = str(uuid.uuid4())
             rev = str(uuid.uuid4())[:8]
@@ -726,18 +778,30 @@ def test_driver_get_all_versions():
             form = "object"
             created_date = datetime.now()
             updated_date = created_date
-
+            content_created_date = datetime.now()
+            content_updated_date = created_date
             dids.append(did)
             revs.append(rev)
             created_dates.append(created_date)
             updated_dates.append(updated_date)
-
+            content_created_dates.append(content_created_date)
+            content_updated_dates.append(content_updated_date)
             conn.execute(
                 """
-                INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date) \
-                    VALUES (?,?,?,?,?,?,?)
+                INSERT INTO index_record(did, baseid, rev, form, size, created_date, updated_date, content_created_date, content_updated_date) \
+                    VALUES (?,?,?,?,?,?,?,?,?)
             """,
-                (did, baseid, rev, form, size, created_date, updated_date),
+                (
+                    did,
+                    baseid,
+                    rev,
+                    form,
+                    size,
+                    created_date,
+                    updated_date,
+                    content_created_date,
+                    content_updated_date,
+                ),
             )
 
         conn.commit()

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -109,24 +109,18 @@ def verify_timestamps(expected_doc, did, client, has_updated_date=True):
 
     record_resp = client.get(f"/index/{did}")
     assert record_resp.status_code == 200
+    assert expected_doc["content_created_date"] == drs_resp.json["created_time"]
+    assert (
+        expected_doc["content_created_date"] == record_resp.json["content_created_date"]
+    )
     if has_updated_date:
-        assert expected_doc["content_created_date"] == drs_resp.json["created_time"]
         assert expected_doc["content_updated_date"] == drs_resp.json["updated_time"]
-        assert (
-            expected_doc["content_created_date"]
-            == record_resp.json["content_created_date"]
-        )
         assert (
             expected_doc["content_updated_date"]
             == record_resp.json["content_updated_date"]
         )
     else:
-        assert expected_doc["content_created_date"] == drs_resp.json["created_time"]
         assert expected_doc["content_created_date"] == drs_resp.json["updated_time"]
-        assert (
-            expected_doc["content_created_date"]
-            == record_resp.json["content_created_date"]
-        )
         assert (
             expected_doc["content_created_date"]
             == record_resp.json["content_updated_date"]
@@ -163,6 +157,9 @@ def test_changing_timestamps(client, user):
 
 
 def test_timestamps_updated_sets_to_created(client, user):
+    """
+    Checks that content_updated_date is set to content_created_date when none is provided.
+    """
     data = get_doc(has_content_updated_date=False)
     create_obj_resp = client.post("/index/", json=data, headers=user)
     assert create_obj_resp.status_code == 200

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -28,8 +28,8 @@ def get_doc(
     has_version=True,
     urls=list(),
     has_description=True,
-    has_created_time=True,
-    has_updated_time=True,
+    has_content_created_date=True,
+    has_content_updated_date=True,
 ):
     doc = {
         "form": "object",
@@ -43,10 +43,10 @@ def get_doc(
         doc["urls"] = urls
     if has_description:
         doc["description"] = "A description"
-    if has_updated_time:
-        doc["updated_time"] = "2023-03-14T17:02:54"
-    if has_created_time:
-        doc["created_time"] = "2023-03-13T17:02:54"
+    if has_content_updated_date:
+        doc["content_updated_date"] = "2023-03-14T17:02:54"
+    if has_content_created_date:
+        doc["content_created_date"] = "2023-03-13T17:02:54"
 
     return doc
 
@@ -110,8 +110,8 @@ def test_timestamps(client, user):
     obj_did = create_obj_resp.json["did"]
     obj_resp = client.get(f"/ga4gh/drs/v1/objects/{obj_did}")
     assert obj_resp.status_code == 200
-    assert data["created_time"] == obj_resp.json["created_time"]
-    assert data["updated_time"] == obj_resp.json["updated_time"]
+    assert data["content_created_date"] == obj_resp.json["created_time"]
+    assert data["content_updated_date"] == obj_resp.json["updated_time"]
 
 
 def test_changing_timestamps(client, user):
@@ -121,8 +121,8 @@ def test_changing_timestamps(client, user):
     obj_did = create_obj_resp.json["did"]
     obj_rev = create_obj_resp.json["rev"]
     update_json = {
-        "created_time": "2023-03-15T17:02:54",
-        "updated_time": "2023-03-30T17:02:54",
+        "content_created_date": "2023-03-15T17:02:54",
+        "content_updated_date": "2023-03-30T17:02:54",
     }
     update_obj_resp = client.put(
         f"/index/{obj_did}?rev={obj_rev}", json=update_json, headers=user
@@ -131,8 +131,8 @@ def test_changing_timestamps(client, user):
     update_obj_did = update_obj_resp.json["did"]
     obj_resp = client.get(f"/ga4gh/drs/v1/objects/{update_obj_did}")
     assert obj_resp.status_code == 200
-    assert update_json["created_time"] == obj_resp.json["created_time"]
-    assert update_json["updated_time"] == obj_resp.json["updated_time"]
+    assert update_json["content_created_date"] == obj_resp.json["created_time"]
+    assert update_json["content_updated_date"] == obj_resp.json["updated_time"]
 
 
 def test_changing_timestamps_updated_not_before_created(client, user):
@@ -142,8 +142,8 @@ def test_changing_timestamps_updated_not_before_created(client, user):
     obj_did = create_obj_resp.json["did"]
     obj_rev = create_obj_resp.json["rev"]
     update_json = {
-        "created_time": "2023-03-15T17:02:54",
-        "updated_time": "2022-03-30T17:02:54",
+        "content_created_date": "2023-03-15T17:02:54",
+        "content_updated_date": "2022-03-30T17:02:54",
     }
     update_obj_resp = client.put(
         f"/index/{obj_did}?rev={obj_rev}", json=update_json, headers=user
@@ -152,12 +152,12 @@ def test_changing_timestamps_updated_not_before_created(client, user):
 
 
 def test_changing_timestamps_no_updated_without_created(client, user):
-    data = get_doc(has_created_time=False, has_updated_time=False)
+    data = get_doc(has_content_created_date=False, has_content_updated_date=False)
     create_obj_resp = client.post("/index/", json=data, headers=user)
     assert create_obj_resp.status_code == 200
     obj_did = create_obj_resp.json["did"]
     obj_rev = create_obj_resp.json["rev"]
-    update_json = {"updated_time": "2022-03-30T17:02:54"}
+    update_json = {"content_updated_date": "2022-03-30T17:02:54"}
     update_obj_resp = client.put(
         f"/index/{obj_did}?rev={obj_rev}", json=update_json, headers=user
     )
@@ -166,30 +166,32 @@ def test_changing_timestamps_no_updated_without_created(client, user):
 
 def test_timestamps_updated_not_before_created(client, user):
     data = get_doc()
-    data["updated_time"] = "2022-03-14T17:02:54"  # get_doc sets created year to 2023
+    data[
+        "content_updated_date"
+    ] = "2022-03-14T17:02:54"  # get_doc sets created year to 2023
     create_obj_resp = client.post("/index/", json=data, headers=user)
     assert create_obj_resp.status_code == 400
 
 
 def test_timestamps_no_updated_without_created(client, user):
-    data = get_doc(has_created_time=False)
+    data = get_doc(has_content_created_date=False)
     create_obj_resp = client.post("/index/", json=data, headers=user)
     assert create_obj_resp.status_code == 400
 
 
 def test_timestamps_updated_sets_to_created(client, user):
-    data = get_doc(has_updated_time=False)
+    data = get_doc(has_content_updated_date=False)
     create_obj_resp = client.post("/index/", json=data, headers=user)
     assert create_obj_resp.status_code == 200
     obj_did = create_obj_resp.json["did"]
     obj_resp = client.get(f"/ga4gh/drs/v1/objects/{obj_did}")
     assert obj_resp.status_code == 200
-    assert data["created_time"] == obj_resp.json["created_time"]
-    assert data["created_time"] == obj_resp.json["updated_time"]
+    assert data["content_created_date"] == obj_resp.json["created_time"]
+    assert data["content_created_date"] == obj_resp.json["updated_time"]
 
 
 def test_timestamps_none(client, user):
-    data = get_doc(has_updated_time=False, has_created_time=False)
+    data = get_doc(has_content_updated_date=False, has_content_created_date=False)
     create_obj_resp = client.post("/index/", json=data, headers=user)
     assert create_obj_resp.status_code == 200
     obj_did = create_obj_resp.json["did"]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -24,6 +24,9 @@ INDEX_TABLES = {
         (7, "file_name", "VARCHAR", 0, None, 0),
         (8, "version", "VARCHAR", 0, None, 0),
         (9, "uploader", "VARCHAR", 0, None, 0),
+        (10, "description", "VARCHAR", 0, None, 0),
+        (11, "content_created_date", "DATETIME", 0, None, 0),
+        (12, "content_updated_date", "DATETIME", 0, None, 0),
     ],
     "index_record_hash": [
         (0, "did", "VARCHAR", 1, None, 1),


### PR DESCRIPTION
Jira Ticket: [DCF-450](https://ctds-planx.atlassian.net/browse/DCF-450)


### New Features
- Adds description, content_updated_time and content_created_time to IndexRecord.
- DRS responses now map updated_time and created_time to the underlying content's updated and created times. 
- DRS responses now include index_created_time and index_updated_time to denote the time they were indexed and the time their index record was changed. These fields replace the previous updated_time and created_time in older indexd versions. 

### Breaking Changes
 - DRS responses for update_time and created_time reflect the content's updated and created times, not the time the were indexed or their index record was updated. 

### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- New columns added to index_record table. Alembic migration needed. 


[DCF-450]: https://ctds-planx.atlassian.net/browse/DCF-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ