### PR TITLE
Allow any python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "3.9.*"
 alembic = "^1.9.4"
 authutils = "^6.0.0"
 cdislogging = "^1.0.0"


### PR DESCRIPTION


### Dependency updates
- Allow any Python 3.9.*
