### PR TITLE
Change content date defaults to None from ''

### DIFF
--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -527,7 +527,10 @@ def put_index_record(record):
 
     rev = flask.request.args.get("rev")
     json = flask.request.json
-    if "content_updated_date" in json and "content_created_date" in json:
+    if (
+        json.get("content_updated_date") is not None
+        and json.get("content_created_date") is not None
+    ):
         if json["content_updated_date"] < json["content_created_date"]:
             raise UserError(
                 "content_updated_date cannot come before content_created_date"

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -126,12 +126,12 @@ class IndexRecord(Base):
         content_created_date = (
             self.content_created_date.isoformat()
             if self.content_created_date is not None
-            else ""
+            else None
         )
         content_updated_date = (
             self.content_updated_date.isoformat()
             if self.content_created_date is not None
-            else ""
+            else None
         )
 
         return {
@@ -1250,11 +1250,11 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
                 create_urls_metadata(changing_fields["urls_metadata"], record, session)
 
-            if "content_created_date" in changing_fields:
+            if changing_fields.get("content_created_date") is not None:
                 record.content_created_date = datetime.datetime.fromisoformat(
                     changing_fields["content_created_date"]
                 )
-            if "content_updated_date" in changing_fields:
+            if changing_fields.get("content_updated_date") is not None:
                 if record.content_created_date is None:
                     raise UserError(
                         "Cannot set content_updated_date on record that does not have a content_created_date"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexd"
-version = "3.5.0"
+version = "5.0.0"
 description = "Gen3 Indexing Service"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2676,6 +2676,25 @@ def test_changing_timestamps_updated_not_before_created(client, user):
     assert update_obj_resp.status_code == 400
 
 
+def test_changing_none_timestamps(client, user):
+    """
+    Checks that updates with null values are handled correctly
+    """
+    data = get_doc()
+    create_obj_resp = client.post("/index/", json=data, headers=user)
+    assert create_obj_resp.status_code == 200
+    obj_did = create_obj_resp.json["did"]
+    obj_rev = create_obj_resp.json["rev"]
+    update_json = {
+        "content_created_date": None,
+        "content_updated_date": None,
+    }
+    update_obj_resp = client.put(
+        f"/index/{obj_did}?rev={obj_rev}", json=update_json, headers=user
+    )
+    assert update_obj_resp.status_code == 200
+
+
 def test_changing_timestamps_no_updated_without_created(client, user):
     """
     Checks that records cannot be updated to have a content_updated_date when a content_created_date does not exist

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -174,12 +174,12 @@ def test_timestamps_none(client, user):
     obj_did = create_obj_resp.json["did"]
     drs_resp = client.get(f"/ga4gh/drs/v1/objects/{obj_did}")
     assert drs_resp.status_code == 200
-    assert drs_resp.json.get("created_time") == ""
-    assert drs_resp.json.get("updated_time") == ""
+    assert drs_resp.json.get("created_time") is None
+    assert drs_resp.json.get("updated_time") is None
     record_resp = client.get(f"/index/{obj_did}")
     assert record_resp.status_code == 200
-    assert record_resp.json.get("content_created_date") == ""
-    assert record_resp.json.get("content_updated_date") == ""
+    assert record_resp.json.get("content_created_date") is None
+    assert record_resp.json.get("content_updated_date") is None
     assert drs_resp.json["index_created_time"] == record_resp.json["created_date"]
     assert drs_resp.json["index_updated_time"] == record_resp.json["updated_date"]
 


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes
- Indexd records no longer return empty strings for content_updated_date and content_updated_time when not provided.

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
