### PR TITLE
feature/rbac-2

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,73 @@
+
+**Problem:**
+As an indexd or DRS user, when I list objects, I only expect to see items that belong to projects I have access to.
+
+**Solution:**
+Assuming a Bearer token is included on the request, I expect indexd to query arborist, extract the projects I have access to and add those as an "authz" filter when querying the database.  A feature flag should control this query injection, the flag should default to FALSE, as this will improve chances of getting a PR approved.  All current unit tests should pass.  Additional unit tests should confirm behavior.
+
+**Alternatives:**
+We could have a RBAC aware proxy front end indexd - however will add complexity and processing overhead
+
+**Context:**
+Main [auth code](https://github.com/uc-cdis/indexd/blob/fb21317f2bc72ad9b0ea143fe9388122f59d10f4/indexd/auth/drivers/alchemy.py#L37-L36) has two methods `auth` and `authz`. The [indexd.authorize](https://github.com/uc-cdis/indexd/blob/0859c639f99a7cbce0a0cd15564ed9847814a5ff/indexd/auth/__init__.py#L10) method checks if Basic auth header is present auth is called otherwise authz is called.   The revproxy gateway injects this header [here](https://github.com/uc-cdis/gen3-helm/blob/9ccd25c3e4c40f87f750883802ece5866cdfbc24/helm/revproxy/gen3.nginx.conf/indexd-service.conf#L41-L53) This reliance on Basic auth is concerning and it's rationale is undocumented.  It appears that it is not used for either create or read based on [client API](https://github.com/uc-cdis/indexclient/blob/master/indexclient/client.py)
+
+**Approach:**
+Add code to [get_index](https://github.com/uc-cdis/indexd/blob/b6ec68f15a8bb61e99c0daf3f6af729691f213c7/indexd/index/blueprint.py#L60) to call [auth_mapping](https://github.com/uc-cdis/gen3authz/blob/master/src/gen3authz/client/arborist/base.py#L286)
+and inject resources (projects) into query.
+- [x] skip if feature flag not enabled
+- [x] call arborist with token to get resources for user, or without token to get default resources
+- [x] Cache arborist results for 30 minutes (typical JWT token lifetime)
+- [x] update dependency gen3authz as latest version includes token as parameter (as an alternative to username)
+- [x] use [mock_arborist_requests](https://github.com/uc-cdis/indexd/blob/8ff50b9c829920907181d5c186c907e06f5c4a5d/tests/conftest.py#L230) pytest fixture
+- [x] ensure all existing tests pass
+- [x] add new tests specific to RBAC
+- [x] Add feature flag to [default_settings](https://github.com/uc-cdis/indexd/blob/8ff50b9c829920907181d5c186c907e06f5c4a5d/indexd/default_settings.py)
+- [x] Remove extraneous logging and debugging code
+- [ ] Ensure ARE_RECORDS_DISCOVERABLE, GLOBAL_DISCOVERY_AUTHZ See [discussion](https://github.com/uc-cdis/indexd/pull/400#discussion_r2243579240)
+- [ ] Add a corresponding feature flag to helm chart
+
+---
+# reviewers guide
+
+## Setup Instructions
+* See [docs/local_dev_environment.md](docs/local_dev_environment.md) for details on setting up a local development environment.
+
+## Testing
+* See [pytest](https://github.com/uc-cdis/indexd?tab=readme-ov-file#testing)
+  * Suggest doing this on master first branch to ensure all tests pass
+
+## Code Review
+* Main changes were made to:
+  * indexd/auth
+  * indexd/index/drivers/alchemy.py
+* All of the changes above:
+  * should be transparent to the user, and they should not notice any difference in behavior.
+  * should be non-breaking, as it only changes the behavior when the `authz` parameter is empty.
+  * However, it will throw a 401/403 is the user does not have access to the requested resource,or does not have and Authorization header which is a change from the previous behavior where it would return all the records regardless of the user's access.
+* "Breaking" Changes:
+  * In order to enforce authorization, we need to ensure that all records have an `authz` field.
+  * (This is not a change in behavior to OHSU/ACED/Calypr, but it is a change in behavior to the Indexd API in that effectively authz is mandatory on write)
+* Misc:
+  * Added stack traces to log for unhandled exceptions see changes to blueprint.py for various endpoints
+* Tests:
+
+**Architecture Rationale for `tests/rbac`**
+
+The `tests/rbac` suite is designed to validate RBAC-aware behavior in the indexd service, while ensuring the stability and integrity of legacy functionality. The following principles guide its architecture:
+
+- **Preservation of Existing Tests:**  
+  All pre-existing tests are retained without modification to guarantee backward compatibility and to ensure that legacy functionality remains unaffected by the introduction of RBAC features.
+
+- **Comprehensive Endpoint Coverage:**  
+  New tests are introduced to exercise RBAC logic across a wide set of API endpoints (e.g., list, read, write, update, delete). This ensures that authorization checks are consistently enforced and that the feature flag, token handling, and resource filtering behave as intended in every context.
+
+- **Parameterized Test Design:**  
+  Parameterized tests are used to efficiently cover combinations of public, controlled, and private `authz` resources, as well as users with and without tokens. This approach ensures all relevant access patterns are validated, including edge cases, without duplicating test logic.
+
+- **Mocked Authorization Backend:**  
+  Arborist responses are mocked to provide deterministic and isolated test scenarios, enabling reliable validation of access control logic without external dependencies.
+
+- **Feature Flag Validation:**  
+  Tests verify both enabled and disabled states of the RBAC feature flag, confirming that the system defaults to legacy behavior unless explicitly configured otherwise.
+
+This approach ensures robust coverage of the new RBAC functionality while maintaining the integrity and reliability of the existing test suite.    

--- a/indexd/auth/__init__.py
+++ b/indexd/auth/__init__.py
@@ -3,7 +3,8 @@ from functools import wraps
 from flask import current_app
 from flask import request
 
-from .errors import AuthError
+from indexd.auth.errors import AuthError, AuthzError
+from indexd.errors import UserError
 
 
 def authorize(*p):
@@ -20,8 +21,8 @@ def authorize(*p):
 
         @wraps(f)
         def check_auth(*args, **kwargs):
-            if not request.authorization:
-                raise AuthError("Username / password required.")
+            if not request.authorization.parameters.get("username"):
+                raise AuthError(f"Basic auth Username / password required. {request.authorization}")
             current_app.auth.auth(
                 request.authorization.parameters.get("username"),
                 request.authorization.parameters.get("password"),
@@ -31,13 +32,20 @@ def authorize(*p):
 
         return check_auth
     else:
-        method, resources = p
+        method, resources_ = p
         if request.authorization and request.authorization.type == "basic":
             current_app.auth.auth(
                 request.authorization.parameters.get("username"),
                 request.authorization.parameters.get("password"),
             )
         else:
-            if not isinstance(resources, list):
-                raise UserError(f"'authz' must be a list, received '{resources}'.")
-            current_app.auth.authz(method, list(set(resources)))
+            if not isinstance(resources_, list):
+                raise UserError(f"'authz' must be a list, received '{resources_}'.")
+            return current_app.auth.authz(method, list(set(resources_)))
+
+
+def resources():
+    """
+    Returns a list of resources the user has access to. Uses Arborist if available.
+    """
+    return current_app.auth.resources()

--- a/indexd/auth/driver.py
+++ b/indexd/auth/driver.py
@@ -43,3 +43,11 @@ class AuthDriverABC(SQLAlchemyDriverBase, metaclass=abc.ABCMeta):
         Raises AuthError if user doesn't exist.
         """
         raise NotImplementedError("TODO")
+
+    @abc.abstractmethod
+    def resources(self):
+        """
+        Returns a list of resources the user has access to. Uses Arborist if available.
+        Raises AuthError if the user doesn't exist.
+        """
+        raise NotImplementedError("TODO")

--- a/indexd/auth/drivers/__init__.py
+++ b/indexd/auth/drivers/__init__.py
@@ -1,0 +1,24 @@
+import functools
+import time
+
+
+def timed_cache(ttl_seconds):
+    """
+    Decorator to cache the result of a function for a specified time-to-live (TTL) in seconds.
+    """
+    def decorator(func):
+        cache = {}
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            key = functools._make_key(args, kwargs, typed=False)
+            now = time.time()
+            if key in cache:
+                result, timestamp = cache[key]
+                if now - timestamp < ttl_seconds:
+                    return result
+            result = func(*args, **kwargs)
+            cache[key] = (result, now)
+            return result
+        return wrapper
+    return decorator

--- a/indexd/auth/drivers/alchemy.py
+++ b/indexd/auth/drivers/alchemy.py
@@ -1,4 +1,5 @@
 import hashlib
+import sys
 
 from contextlib import contextmanager
 
@@ -11,6 +12,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.ext.declarative import declarative_base
 
 from indexd.auth.driver import AuthDriverABC
+from indexd.auth.drivers import timed_cache
 
 from indexd.auth.errors import AuthError, AuthzError
 
@@ -133,14 +135,13 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
         try:
             # A successful call from arborist returns a bool, else returns ArboristError
             try:
-                authorized = self.arborist.auth_request(
-                    get_jwt_token(), "indexd", method, resource
-                )
+                authorized = self.cached_auth_request(get_jwt_token(), "indexd", method, resource)
             except Exception as e:
                 logger.error(
                     f"Request to Arborist failed; now checking admin access. Details:\n{e}"
                 )
                 authorized = False
+
             if not authorized:
                 # admins can perform all operations
                 is_admin = self.arborist.auth_request(
@@ -157,7 +158,53 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
                             "The indexd admin '/programs' logic is deprecated. Please update your policy to '/services/indexd/admin'"
                         )
                 if not is_admin:
-                    raise AuthError("Permission denied.")
+                    raise AuthError("Permission denied. (not is_admin)")
         except Exception as err:
             logger.error(err)
             raise AuthzError(err)
+
+    def resources(self):
+        """
+        Returns a list of resources for the given user.
+        """
+        if not self.arborist:
+            raise AuthError(
+                "Arborist is not configured; cannot perform authorization check"
+            )
+        token = get_jwt_token()
+        try:
+            resources = self.caching_auth_mapping(token)
+            return resources
+        except Exception as err:
+            raise AuthError(
+                "Failed to get resources from Arborist. Please check your Arborist configuration."
+            )
+
+    @timed_cache(1800)  # Cache for 30 minutes (typical JWT expiration time)
+    def caching_auth_mapping(self, token):
+        """
+        Returns a list of resources the user has access to.
+        Uses Arborist if available.
+        If a token is provided, it will use that token to get the auth mapping.
+        If no token is provided, it will use the default auth mapping.
+        """
+        if token:
+            resources = self.arborist.auth_mapping(
+                jwt=token
+            )
+        else:
+            resources = self.arborist.auth_mapping()
+        return resources
+
+    @timed_cache(1800)  # Cache for 30 minutes (typical JWT expiration time)
+    def cached_auth_request(self, token, service, method, resource):
+        """
+        Makes an authenticated request to Arborist and caches the result.
+        This method is used to check if the user has access to a specific resource
+        with a specific method.
+        """
+        return self.arborist.auth_request(
+            token, service, method, resource
+        )
+
+

--- a/indexd/blueprint.py
+++ b/indexd/blueprint.py
@@ -1,3 +1,6 @@
+import sys
+
+import cdislogging
 import flask
 
 from indexclient.client import IndexClient
@@ -5,6 +8,7 @@ from doiclient.client import DOIClient
 from dosclient.client import DOSClient
 from hsclient.client import HSClient
 
+from indexd.auth import AuthzError
 from indexd.utils import hint_match
 
 from indexd.errors import AuthError
@@ -12,12 +16,20 @@ from indexd.errors import UserError
 from indexd.alias.errors import NoRecordFound as AliasNoRecordFound
 from indexd.index.errors import NoRecordFound as IndexNoRecordFound
 
+logger = cdislogging.get_logger(__name__)
+
 blueprint = flask.Blueprint("cross", __name__)
 
 blueprint.config = dict()
 blueprint.index_driver = None
 blueprint.alias_driver = None
 blueprint.dist = []
+
+
+@blueprint.errorhandler(Exception)
+def handle_uncaught_exception(err):
+    logger.error(err, exc_info=True)
+    return flask.jsonify(error="Internal server error"), 500
 
 
 @blueprint.route("/alias/<path:alias>", methods=["GET"])
@@ -60,7 +72,6 @@ def get_record(record):
                 if not blueprint.dist or "no_dist" in flask.request.args:
                     raise
                 ret = dist_get_record(record)
-
     return flask.jsonify(ret), 200
 
 
@@ -109,6 +120,11 @@ def handle_user_error(err):
 @blueprint.errorhandler(AuthError)
 def handle_auth_error(err):
     return flask.jsonify(error=str(err)), 403
+
+
+@blueprint.errorhandler(AuthzError)
+def handle_authz_error(err):
+    return flask.jsonify(error=str(err)), 401
 
 
 @blueprint.errorhandler(AliasNoRecordFound)

--- a/indexd/default_settings.py
+++ b/indexd/default_settings.py
@@ -83,6 +83,8 @@ CONFIG["DRS_SERVICE_INFO"] = {
     },
 }
 
+CONFIG["RBAC"] = False  # RBAC is not enabled by default
+
 AUTH = SQLAlchemyAuthDriver(
     "postgresql://postgres:postgres@localhost:5432/indexd_tests"  # pragma: allowlist secret
 )

--- a/indexd/dos/blueprint.py
+++ b/indexd/dos/blueprint.py
@@ -1,5 +1,8 @@
+
+import cdislogging
 import flask
 
+from indexd.auth import AuthzError
 from indexd.blueprint import dist_get_record
 
 from indexd.errors import AuthError
@@ -7,6 +10,7 @@ from indexd.errors import UserError
 from indexd.alias.errors import NoRecordFound as AliasNoRecordFound
 from indexd.index.errors import NoRecordFound as IndexNoRecordFound
 
+logger = cdislogging.get_logger(__name__)
 blueprint = flask.Blueprint("dos", __name__)
 
 blueprint.config = dict()
@@ -15,12 +19,34 @@ blueprint.alias_driver = None
 blueprint.dist = []
 
 
+@blueprint.errorhandler(Exception)
+def handle_uncaught_exception(err):
+    logger.error(err, exc_info=True)
+    return flask.jsonify(error=f"Internal server error"), 500
+
+
+@blueprint.errorhandler(AuthzError)
+def handle_authz_error(err):
+    ret = {"msg": str(err), "status_code": 401}
+    return flask.jsonify(ret), 401
+
+
+@blueprint.errorhandler(AuthError)
+def handle_requester_auth_error(err):
+    """
+    Handle auth errors that occur when the requester is not authorized to access the resource.
+    """
+    ret = {"msg": str(err), "status_code": 403}
+    return flask.jsonify(ret), 403
+
+
 @blueprint.route("/ga4gh/dos/v1/dataobjects/<path:record>", methods=["GET"])
 def get_dos_record(record):
     """
     Returns a record from the local ids, alias, or global resolvers.
     Returns DOS Schema
     """
+
     try:
         ret = blueprint.index_driver.get(record)
         # record may be a baseID or a DID / GUID. If record is a baseID, ret["did"] is the latest GUID for that record.

--- a/indexd/drs/blueprint.py
+++ b/indexd/drs/blueprint.py
@@ -1,5 +1,6 @@
 import os
-import re
+
+import cdislogging
 import flask
 import json
 from indexd.errors import AuthError, AuthzError
@@ -7,6 +8,8 @@ from indexd.errors import UserError
 from indexd.index.errors import NoRecordFound as IndexNoRecordFound
 from indexd.errors import IndexdUnexpectedError
 from indexd.utils import reverse_url
+
+logger = cdislogging.get_logger(__name__)
 
 blueprint = flask.Blueprint("drs", __name__)
 
@@ -367,6 +370,15 @@ def handle_no_index_record_error(err):
 def handle_unexpected_error(err):
     ret = {"msg": err.message, "status_code": err.code}
     return flask.jsonify(ret), err.code
+
+
+@blueprint.errorhandler(Exception)
+def handle_uncaught_exception(err):
+    """
+    Handle uncaught exceptions and log them.
+    """
+    logger.error(err, exc_info=True)
+    return flask.jsonify(error=f"Internal server error"), 500
 
 
 @blueprint.record

--- a/indexd/index/blueprint.py
+++ b/indexd/index/blueprint.py
@@ -1,8 +1,12 @@
 import re
 import json
+import sys
+
 import flask
 import hashlib
 import jsonschema
+from werkzeug.exceptions import BadRequest
+
 from ..version_data import VERSION, COMMIT
 
 from indexd import auth
@@ -106,6 +110,7 @@ def get_index(form=None):
     hashes = hashes if hashes else None
     metadata = flask.request.args.getlist("metadata")
     metadata = {k: v for k, v in (x.split(":", 1) for x in metadata)}
+
     acl = flask.request.args.get("acl")
     if acl is not None:
         acl = [] if acl == "null" else acl.split(",")
@@ -151,6 +156,7 @@ def get_index(form=None):
             urls_metadata=urls_metadata,
             negate_params=negate_params,
         )
+
     else:
         records = blueprint.index_driver.ids(
             start=start,
@@ -263,12 +269,12 @@ def append_aliases(record):
     Append one or more aliases to aliases already associated with this
     DID / GUID, if any.
     """
-    # we set force=True so that if MIME type of request is not application/JSON,
-    # get_json will still throw a UserError.
-    aliases_json = flask.request.get_json(force=True)
     try:
+        # we set force=True so that if MIME type of request is not application/JSON,
+        # get_json will still throw a UserError.
+        aliases_json = flask.request.get_json(force=True)
         jsonschema.validate(aliases_json, RECORD_ALIAS_SCHEMA)
-    except jsonschema.ValidationError as err:
+    except (jsonschema.ValidationError, BadRequest)as err:
         # TODO I BELIEVE THIS IS WHERE THE ERROR IS
         logger.warning(f"Bad request body:\n{err}")
         raise UserError(err)
@@ -288,12 +294,12 @@ def replace_aliases(record):
     """
     Replace all aliases associated with this DID / GUID
     """
-    # we set force=True so that if MIME type of request is not application/JSON,
-    # get_json will still throw a UserError.
-    aliases_json = flask.request.get_json(force=True)
     try:
+        # we set force=True so that if MIME type of request is not application/JSON,
+        # get_json will still throw a UserError.
+        aliases_json = flask.request.get_json(force=True)
         jsonschema.validate(aliases_json, RECORD_ALIAS_SCHEMA)
-    except jsonschema.ValidationError as err:
+    except (jsonschema.ValidationError, BadRequest) as err:
         logger.warning(f"Bad request body:\n{err}")
         raise UserError(err)
 
@@ -834,6 +840,12 @@ def handle_revision_mismatch(err):
 @blueprint.errorhandler(UnhealthyCheck)
 def handle_unhealthy_check(err):
     return "Unhealthy", 500
+
+
+@blueprint.errorhandler(Exception)
+def handle_uncaught_exception(err):
+    logger.error(err, exc_info=True)
+    return flask.jsonify(error=f"Internal server error {type(err)} {err}"), 500
 
 
 @blueprint.record

--- a/indexd/index/drivers/alchemy.py
+++ b/indexd/index/drivers/alchemy.py
@@ -2,6 +2,8 @@ import datetime
 import uuid
 import json
 from contextlib import contextmanager
+
+import flask
 from cdislogging import get_logger
 from sqlalchemy import (
     BigInteger,
@@ -24,6 +26,7 @@ from sqlalchemy.orm import joinedload, relationship, sessionmaker
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from indexd import auth
+from indexd.auth.errors import AuthzError
 from indexd.errors import UserError, AuthError
 from indexd.index.driver import IndexDriverABC
 from indexd.index.errors import (
@@ -35,6 +38,79 @@ from indexd.index.errors import (
 from indexd.utils import migrate_database
 
 Base = declarative_base()
+
+
+def _get_authorized_resources(requested_method="READ") -> list[str]:
+    """Retrieve the user's authorized resources from Arborist."""
+    # Token is __not__ required for RBAC, but we can use it to get the user's context.
+    # See https://github.com/uc-cdis/indexd/pull/400#discussion_r2243298256
+    # `Arborist allows no token to be sent on purpose, it allows assignment of anonymous access. So we don't want to raise this error here`
+    # if not flask.request.authorization:
+    #     raise AuthError("Authorization header is required for RBAC")
+    # token = flask.request.headers.get("Authorization")
+    # if token is None:
+    #     raise AuthError("Authorization header is required for RBAC")
+    authorized_resources = []
+    for resource, permissions in auth.resources().items():
+        for permission in permissions:
+            method = permission['method']
+            service = permission['service']
+            if requested_method == "READ":
+                if "read-storage" == method or service == "indexd":
+                    authorized_resources.append(resource)
+            else:
+                if method in ["create", "update", "delete"]:
+                    authorized_resources.append(resource)
+    return authorized_resources
+
+
+def _check_user_access(authorized_resources: list[str], authz: list[str]) -> None:
+    """Raise an AuthzError if the user is not authorized for the given resources."""
+    for resource in authz:
+        if resource not in authorized_resources:
+            raise AuthzError(
+                f"User is not authorized for project {resource} {authz} {type(authz)}"
+            )
+
+
+def _is_rbac() -> bool:
+    """ Check if RBAC is enabled for the current app."""
+    # For simplicity, we check the config directly.
+    return flask.current_app.config.get('RBAC', False)
+
+
+def _enforce_rbac(authz, method="READ") -> tuple[list[str], list[str]]:
+    """ Enforce RBAC for the current request."""
+    any_authz = None
+    if _is_rbac():
+        # If RBAC is not enabled, we don't need to check user access.
+        # This is for backwards compatibility with existing code.
+        authorized_resources = _get_authorized_resources(method)
+        if len(authorized_resources) == 0:
+            # Force filtering by an non-existent resource if no resources are authorized.
+            authorized_resources = ["NO-AUTHORIZED-RESOURCES"]
+        if authz:
+            _check_user_access(authorized_resources, authz or [])
+            any_authz = None
+        else:
+            authz = None
+            any_authz = authorized_resources
+
+    return any_authz, authz
+
+
+def _enforce_record_authz(record):
+    """ Enforce record authorization based on the current request's RBAC settings."""
+    if not _is_rbac():
+        return
+    authorized_resources = _get_authorized_resources()
+    if len(authorized_resources) == 0:
+        raise AuthError("User is not authorized for any resources")
+    if isinstance(record, IndexRecord):
+        record = record.to_document_dict()
+    if not isinstance(record, dict):
+        raise UserError("Record must be a dictionary")
+    _check_user_access(authorized_resources, record.get("authz", []))
 
 
 class BaseVersion(Base):
@@ -389,11 +465,14 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         metadata=None,
         ids=None,
         urls_metadata=None,
-        negate_params=None,
+        negate_params=None
     ):
         """
         Returns list of records stored by the backend.
         """
+
+        any_authz, authz = _enforce_rbac(authz)
+
         with self.session as session:
             query = session.query(IndexRecord)
 
@@ -450,7 +529,12 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                     query = query.filter(IndexRecord.did.in_(sub.subquery()))
             elif authz == []:
                 query = query.filter(IndexRecord.authz == None)
-
+            elif any_authz:
+                # if any_authz is set, we want to filter records that have ANY of the authz elements
+                sub = session.query(IndexRecordAuthz.did).filter(
+                    IndexRecordAuthz.resource.in_(any_authz)
+                )
+                query = query.filter(IndexRecord.did.in_(sub.subquery().select()))
             if hashes:
                 for h, v in hashes.items():
                     sub = session.query(IndexRecordHash.did)
@@ -534,6 +618,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 query = query.offset(limit * page)
 
             return [i.to_document_dict() for i in query]
+
 
     @staticmethod
     def _negate_filter(
@@ -640,6 +725,8 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Returns a list of urls matching supplied size/hashes/dids.
         """
+        any_authz, authz = _enforce_rbac([])
+
         if size is None and hashes is None and ids is None:
             raise UserError("Please provide size/hashes/ids to filter")
 
@@ -666,6 +753,12 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 query = query.filter(IndexRecordUrl.did.in_(ids))
             # Remove duplicates.
             query = query.distinct()
+            # if any_authz is set, filter by authz
+            if any_authz:
+                sub = session.query(IndexRecordAuthz.did).filter(
+                    IndexRecordAuthz.resource.in_(any_authz)
+                )
+                query = query.filter(IndexRecordUrl.did.in_(sub.subquery().select()))
 
             # Return only specified window.
             query = query.offset(start)
@@ -720,7 +813,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         hashes = hashes or {}
         metadata = metadata or {}
         urls_metadata = urls_metadata or {}
-
+        _enforce_rbac(authz, method="WRITE")
         with self.session as session:
             record = IndexRecord()
 
@@ -941,6 +1034,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Create a index alias with the alias as {prefix:did}
         """
+        _enforce_rbac(record.authz, method="WRITE")
         prefix = self.config["DEFAULT_PREFIX"]
         alias = IndexRecordAlias(did=record.did, name=prefix + record.did)
         session.add(alias)
@@ -960,6 +1054,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 raise NoRecordFound("no record found")
             except MultipleResultsFound:
                 raise MultipleRecordsFound("multiple records found")
+
+            _enforce_record_authz(record)
+
             return record.to_document_dict()
 
     def get_aliases_for_did(self, did):
@@ -973,6 +1070,8 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             if index_record is None:
                 self.logger.warning(f"No record found for did {did}")
                 raise NoRecordFound(did)
+
+            _enforce_record_authz(index_record)
 
             query = session.query(IndexRecordAlias).filter(IndexRecordAlias.did == did)
             return [i.name for i in query]
@@ -1149,7 +1248,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                     # overwrite the "no bundle found" message
                     raise NoRecordFound("no record found")
 
-            return record.to_document_dict()
+            document_dict = record.to_document_dict()
+            _enforce_record_authz(document_dict)
+            return document_dict
 
     def get_with_nonstrict_prefix(self, did, expand=True):
         """
@@ -1170,7 +1271,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             else:
                 stripped = did.split(DEFAULT_PREFIX, 1)[1]
                 record = self.get(stripped, expand=expand)
-
+        _enforce_record_authz(record)
         return record
 
     def update(self, did, rev, changing_fields):
@@ -1480,6 +1581,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Get all record versions (in order of creation) given DID
         """
+        any_authz, authz = _enforce_rbac([])
         ret = dict()
         with self.session as session:
             query = session.query(IndexRecord)
@@ -1498,6 +1600,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 raise MultipleRecordsFound("multiple records found")
 
             query = session.query(IndexRecord)
+
             records = (
                 query.filter(IndexRecord.baseid == baseid)
                 .order_by(IndexRecord.created_date.asc())
@@ -1505,7 +1608,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             )
 
             for idx, record in enumerate(records):
-                ret[idx] = record.to_document_dict()
+                document_dict = record.to_document_dict()
+                _enforce_record_authz(document_dict)
+                ret[idx] = document_dict
 
         return ret
 
@@ -1563,6 +1668,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Get the lattest record version given did
         """
+        any_authz, authz = _enforce_rbac([])
         with self.session as session:
             query = session.query(IndexRecord)
             query = query.filter(IndexRecord.did == did)
@@ -1585,7 +1691,10 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             if not record:
                 raise NoRecordFound("no record found")
 
-            return record.to_document_dict()
+            document_dict = record.to_document_dict()
+            _enforce_record_authz(document_dict)
+
+            return document_dict
 
     def health_check(self):
         """
@@ -1692,6 +1801,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Returns list of all bundles
         """
+        authz, any_authz = _enforce_rbac([])
         with self.session as session:
             query = session.query(DrsBundleRecord)
             query = query.limit(limit)
@@ -1744,6 +1854,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Gets bundles and objects and orders them by created time.
         """
+
         limit = int((limit / 2) + 1)
         bundle = self.get_bundle_list(start=start, limit=limit, page=page)
         objects = self.ids(

--- a/indexd/index/drivers/single_table_alchemy.py
+++ b/indexd/index/drivers/single_table_alchemy.py
@@ -665,7 +665,7 @@ class SingleTableSQLAlchemyIndexDriver(IndexDriverABC):
             record = query.one()
 
             try:
-                record.alias = record.alias + aliases
+                record.alias = record.alias or [] + aliases
                 session.commit()
             except IntegrityError as err:
                 # One or more aliases in request were non-unique

--- a/tests/rbac/conftest.py
+++ b/tests/rbac/conftest.py
@@ -1,0 +1,358 @@
+import base64
+import hashlib
+import importlib
+import datetime
+import uuid
+from unittest import mock
+from unittest.mock import patch
+
+import pytest
+import jwt
+import requests
+from gen3authz.client.arborist.client import ArboristClient
+from sqlalchemy import create_engine
+
+from indexd import get_app
+from indexd.auth.drivers.alchemy import SQLAlchemyAuthDriver
+from tests.conftest import clear_database, logger, POSTGRES_CONNECTION
+
+
+@pytest.fixture
+def public_authz():
+    return "/programs/public/projects/open"
+
+
+@pytest.fixture
+def controlled_authz():
+    return "/programs/controlled/projects/closed"
+
+
+@pytest.fixture
+def private_authz():
+    return "/programs/private/projects/secret"
+
+
+@pytest.fixture()
+def app_with_rbac():
+    from indexd import default_settings
+    from tests import default_test_settings
+
+    importlib.reload(default_settings)
+    importlib.reload(default_test_settings)
+
+    default_test_settings.settings["config"]["RBAC"] = True
+
+    default_settings.settings = {
+        **default_settings.settings,
+        **default_test_settings.settings,
+    }
+    assert default_settings.settings["config"]["RBAC"] is True
+
+    yield get_app(settings=default_settings.settings)
+
+    try:
+        clear_database()
+    except Exception as e:
+        logger.error(f"Failed to clear database with error {e}")
+    default_settings.settings["config"]["RBAC"] = False
+
+
+@pytest.fixture(scope="function")
+def mock_arborist_requests(app_with_rbac, request):
+    """
+    Copied from gen3authz.client.arborist.tests.conftest.py
+    This fixture mocks Arborist requests for testing purposes.
+    """
+    arborist_base_url = "arborist"
+    app_with_rbac.auth.arborist = ArboristClient(arborist_base_url=arborist_base_url)
+
+    def do_patch(resource_method_to_authorized={}):
+        def make_mock_response(method, url, *args, **kwargs):
+            method = method.upper()
+            mocked_response = mock.MagicMock(requests.Response)
+
+            if url not in [
+                f"{arborist_base_url}/auth/request",
+                f"{arborist_base_url}/auth/mapping",
+            ]:
+                mocked_response.status_code = 404
+                mocked_response.text = "NOT FOUND"
+            elif method != "POST":
+                mocked_response.status_code = 405
+                mocked_response.text = "METHOD NOT ALLOWED"
+            else:
+                if url == f"{arborist_base_url}/auth/request":
+                    authz_res, authz_met = None, None
+                    authz_requests = kwargs["json"]["requests"]
+                    if authz_requests:
+                        authz_res = kwargs["json"]["requests"][0]["resource"]
+                        authz_met = kwargs["json"]["requests"][0]["action"]["method"]
+                    authorized = resource_method_to_authorized.get(authz_res, {}).get(
+                        authz_met, False
+                    )
+                    mocked_response.status_code = 200
+                    mocked_response.json.return_value = {"auth": authorized}
+                elif url == f"{arborist_base_url}/auth/mapping":
+                    mocked_response.status_code = 200
+                    return_value = {}
+                    for k, permissions in resource_method_to_authorized.items():
+                        if "read" in permissions and permissions["read"]:
+                            return_value[k] = [
+                                {"service": "*", "method": "read"},
+                                {"service": "*", "method": "read-storage"},
+                            ]
+                        for p in ["create", "update", "delete", "file_upload"]:
+                            if p in permissions and permissions[p]:
+                                if k not in return_value:
+                                    return_value[k] = []
+                                return_value[k].append({"service": "*", "method": p})
+                    mocked_response.json.return_value = return_value
+            return mocked_response
+
+        mocked_method = mock.MagicMock(side_effect=make_mock_response)
+        patch_method = patch(
+            "gen3authz.client.arborist.client.httpx.Client.request", mocked_method
+        )
+
+        patch_method.start()
+        request.addfinalizer(patch_method.stop)
+
+    return do_patch
+
+
+@pytest.fixture
+def client(app_with_rbac):
+    with app_with_rbac.test_client() as client:
+        yield client
+
+
+def user_with_token(username="test"):
+    def create_mock_jwt(username=username, secret="test", algorithm="HS256"):
+        payload = {
+            "sub": username,
+            "iat": datetime.datetime.now(datetime.UTC),
+            "exp": datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1),
+        }
+        token = jwt.encode(payload, secret, algorithm=algorithm)
+        return token
+
+    mock_token = create_mock_jwt()
+    return mock_token
+
+
+@pytest.fixture
+def power_user(mock_arborist_requests, public_authz, controlled_authz, private_authz):
+    engine = create_engine(POSTGRES_CONNECTION)
+    driver = SQLAlchemyAuthDriver(POSTGRES_CONNECTION)
+    try:
+        driver.add("test", "test")
+    except Exception as e:
+        logger.error(f"Failed to add test users with error {e}")
+
+    yield {
+        "permissions": {
+            public_authz: {
+                "read": True,
+                "create": True,
+                "update": True,
+                "delete": True,
+            },
+            controlled_authz: {
+                "read": True,
+                "create": True,
+                "update": True,
+                "delete": True,
+            },
+            private_authz: {
+                "read": True,
+                "create": True,
+                "update": True,
+                "delete": True,
+            },
+            "/programs": {"create": True},
+            "/services/indexd/admin": {
+                "create": True,
+                "update": True,
+                "delete": True,
+                "read": True,
+                "file_upload": True,
+            },
+        },
+        "header": {
+            "Authorization": f"Bearer {user_with_token('power_user')}",
+            "Content-Type": "application/json",
+            "X-Test-User": "power_user",
+        },
+    }
+
+    try:
+        driver.delete("test")
+    except Exception as e:
+        logger.error(f"Failed to delete test user with error {e}")
+
+    engine.dispose()
+
+
+@pytest.fixture
+def controlled_user(mock_arborist_requests, public_authz, controlled_authz):
+    engine = create_engine(POSTGRES_CONNECTION)
+    driver = SQLAlchemyAuthDriver(POSTGRES_CONNECTION)
+    try:
+        driver.add("test", "test")
+    except Exception as e:
+        logger.error(f"Failed to add test users with error {e}")
+
+    yield {
+        "permissions": {
+            public_authz: {
+                "read": True,
+                "create": True,
+                "update": True,
+                "delete": True,
+            },
+            controlled_authz: {
+                "read": True,
+                "create": True,
+                "update": True,
+                "delete": True,
+            },
+            "/programs": {"create": True},
+            "/services/indexd/admin": {
+                "create": True,
+                "update": True,
+                "delete": True,
+                "read": True,
+                "file_upload": True,
+            },
+        },
+        "header": {
+            "Authorization": f"Bearer {user_with_token('controlled_user')}",
+            "Content-Type": "application/json",
+            "X-Test-User": "controlled_user",
+        },
+    }
+
+    try:
+        driver.delete("test")
+    except Exception as e:
+        logger.error(f"Failed to delete test user with error {e}")
+
+    engine.dispose()
+
+
+@pytest.fixture
+def basic_user(mock_arborist_requests, public_authz):
+    engine = create_engine(POSTGRES_CONNECTION)
+    driver = SQLAlchemyAuthDriver(POSTGRES_CONNECTION)
+    try:
+        driver.add("test", "test")
+    except Exception as e:
+        logger.error(f"Failed to add test users with error {e}")
+
+    yield {
+        "permissions": {
+            public_authz: {"read": True},
+        },
+        "header": {
+            "Authorization": (
+                "Basic " + base64.b64encode(b"test:test").decode("ascii")
+            ),
+            "Content-Type": "application/json",
+            "X-Test-User": "basic_user",
+        },
+    }
+
+    try:
+        driver.delete("test")
+    except Exception as e:
+        logger.error(f"Failed to delete test user with error {e}")
+
+    engine.dispose()
+
+
+@pytest.fixture
+def null_user(basic_user):
+    yield {
+        "permissions": basic_user["permissions"],
+        "header": {
+            "Content-Type": "application/json",
+            "X-Test-User": "null_user",
+        },
+    }
+
+
+def get_doc(
+    authz=None,
+    has_metadata=True,
+    has_baseid=False,
+    has_urls_metadata=False,
+    has_version=False,
+):
+    assert authz, "Authz must be provided"
+    if isinstance(authz, str):
+        authz = [authz]
+    program = project = project_id = None
+    for item in authz:
+        if item.startswith("/programs/"):
+            _ = item.split("/")
+            program = _[2]
+            project = _[4]
+            project_id = f"{program}-{project}"
+            break
+    assert program and project, "Authz must contain a valid program and project"
+    md5_hash = hashlib.md5(project_id.encode("utf-8")).hexdigest()
+    doc = {
+        "form": "object",
+        "size": 123,
+        "urls": [f"s3://endpointurl/{program}/{project}/text.txt"],
+        "hashes": {"md5": md5_hash},
+        "authz": authz,
+    }
+    if has_metadata:
+        doc["metadata"] = {"project_id": project_id}
+    if has_baseid:
+        doc["baseid"] = str(uuid.UUID(md5_hash + "-baseid"))
+    if has_urls_metadata:
+        doc["urls_metadata"] = {"s3://endpointurl/bucket/key": {"state": "uploaded"}}
+    if has_version:
+        doc["version"] = "1"
+    return doc
+
+
+def create_record(client, authz, power_user, mock_arborist_requests):
+    mock_arborist_requests(resource_method_to_authorized=power_user["permissions"])
+    record = get_doc(authz)
+    response = client.post("/index/", json=record, headers=power_user["header"])
+    assert response.status_code == 200, f"Failed to create record: {response.text} {power_user["header"]}"
+    record.update(response.json)
+    aliases = {"aliases": [{"value": f"{authz}-alias"}]}
+    record.update(aliases)
+    response = client.post(
+        f"/index/{record['did']}/aliases", json=aliases, headers=power_user["header"]
+    )
+    assert response.status_code == 200, f"Failed to add alias: {response.text} {power_user["header"]}"
+    return record
+
+
+@pytest.fixture
+def public_record(client, power_user, public_authz, mock_arborist_requests):
+    yield create_record(client, public_authz, power_user, mock_arborist_requests)
+
+
+@pytest.fixture
+def controlled_record(client, power_user, controlled_authz, mock_arborist_requests):
+    yield create_record(client, controlled_authz, power_user, mock_arborist_requests)
+
+
+@pytest.fixture
+def private_record(client, power_user, private_authz, mock_arborist_requests):
+    yield create_record(client, private_authz, power_user, mock_arborist_requests)
+
+
+@pytest.fixture
+def all_records(public_record, controlled_record, private_record):
+    yield {
+        "public": public_record,
+        "controlled": controlled_record,
+        "private": private_record,
+    }

--- a/tests/rbac/test_reads.py
+++ b/tests/rbac/test_reads.py
@@ -1,0 +1,520 @@
+import pytest
+
+
+def _get(client, url, expected_status, user_, mock_arborist_requests) -> dict:
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    res = client.get(url, headers=user_["header"])
+    assert (
+        res.status_code == expected_status
+    ), f"{url} Expected status {expected_status}, got {res.status_code} {res.text} for user {user_['header']}"
+    return res.json
+
+
+def ensure_drs(
+    client, did, expected_count, expected_status, mock_arborist_requests, user_
+):
+    url = f"/ga4gh/drs/v1/objects"
+    response = _get(client, url, expected_status, user_, mock_arborist_requests)
+    if expected_status == 200:
+        assert (
+            "drs_objects" in response
+        ), f"Expected 'drs_objects' in response, got {response} for user {user_['header']}"
+        drs_objects = response["drs_objects"]
+        assert isinstance(
+            drs_objects, list
+        ), f"Expected 'drs_objects' to be a list, got {type(drs_objects)} for user {user_['header']}"
+        assert (
+            len(drs_objects) == expected_count
+        ), f"Expected non-empty 'drs_objects', got {drs_objects} for user {user_['header']}"
+        if expected_count > 0:
+            record = drs_objects[0]
+            assert (
+                "id" in record
+            ), f"Expected 'id' in drs_object, got {record} for user {user_['header']}"
+            assert (
+                record["id"] == did
+            ), f"Expected DID {did}, got {record['id']} for user {user_['header']}"
+    url = f"/ga4gh/drs/v1/objects/{did}"
+    if expected_count == 0:
+        expected_status = 401 if expected_status == 200 else expected_status
+    response = _get(client, url, expected_status, user_, mock_arborist_requests)
+    if expected_count > 0:
+        record = response
+        assert (
+            "id" in record
+        ), f"Expected 'id' in drs_object, got {record} for user {user_['header']}"
+        assert (
+            record["id"] == did
+        ), f"Expected DID {did}, got {record['id']} for user {user_['header']}"
+
+
+def ensure_get_urls(
+    client, did, expected_count, expected_status, mock_arborist_requests, user_
+):
+    url = "/urls"
+    response = _get(client, url, expected_status, user_, mock_arborist_requests)
+    if expected_status == 200:
+        assert (
+            "urls" in response
+        ), f"Expected 'urls' in response, got {response} for user {user_['header']}"
+        urls = response["urls"]
+        assert isinstance(
+            urls, list
+        ), f"Expected 'urls' to be a list, got {type(urls)} for user {user_['header']}"
+        assert (
+            len(urls) == expected_count
+        ), f"Expected non-empty 'urls', got {urls} for user {user_['header']}"
+        if expected_count > 0:
+            record = urls[0]
+            assert (
+                "metadata" in record
+            ), f"Expected 'metadata' in url, got {record} for user {user_['header']}"
+            assert (
+                "url" in record
+            ), f"Expected 'url' in url, got {record} for user {user_['header']}"
+
+
+@pytest.mark.parametrize(
+    "record_fixture, authz_fixture, user_fixture, expected_count",
+    [
+        ("public_record", "public_authz", "power_user", 1),
+        ("public_record", "public_authz", "basic_user", 1),
+        ("public_record", "public_authz", "null_user", 1),
+        ("public_record", "public_authz", "controlled_user", 1),
+        ("controlled_record", "controlled_authz", "power_user", 1),
+        ("controlled_record", "controlled_authz", "basic_user", 0),
+        ("controlled_record", "controlled_authz", "null_user", 0),
+        ("controlled_record", "controlled_authz", "controlled_user", 1),
+        ("private_record", "private_authz", "power_user", 1),
+        ("private_record", "private_authz", "basic_user", 0),
+        ("private_record", "private_authz", "null_user", 0),
+        ("private_record", "private_authz", "controlled_user", 0),
+    ],
+)
+def test_client_get_index_access(
+    client,
+    request,
+    record_fixture,
+    authz_fixture,
+    user_fixture,
+    expected_count,
+    mock_arborist_requests,
+):
+    """
+    Test access to /index/ for all record and user combinations.
+    """
+    user_ = request.getfixturevalue(user_fixture)
+    authz = request.getfixturevalue(authz_fixture)
+    _ = request.getfixturevalue(record_fixture)  # ensure record exists
+
+    rec = _get(client, "/index/", 200, user_, mock_arborist_requests)
+
+    assert (
+        len(rec["records"]) == expected_count
+    ), f"Response should contain {expected_count} record {rec} user: {user_}"
+    if expected_count > 0:
+        assert (
+            authz in rec["records"][0]["authz"]
+        ), f"Record should have the correct authz {authz}, got {rec}"
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status",
+    [
+        ("public_record", "power_user", 200),
+        ("public_record", "controlled_user", 200),
+        ("public_record", "basic_user", 200),
+        ("public_record", "null_user", 200),
+        ("controlled_record", "power_user", 200),
+        ("controlled_record", "controlled_user", 200),
+        ("controlled_record", "basic_user", 401),
+        ("controlled_record", "null_user", 401),
+        ("private_record", "power_user", 200),
+        ("private_record", "controlled_user", 401),
+        ("private_record", "basic_user", 401),
+        ("private_record", "null_user", 401),
+    ],
+)
+def test_get_index_record(
+    client,
+    request,
+    record_fixture,
+    user_fixture,
+    expected_status,
+    mock_arborist_requests,
+):
+    """
+    Test GET /index/{did} for all record and user combinations.
+    """
+    record = request.getfixturevalue(record_fixture)
+    did = record["did"]
+    user_ = request.getfixturevalue(user_fixture)
+    url = f"/index/{did}"
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    res = client.get(url, headers=user_["header"])
+    assert (
+        res.status_code == expected_status
+    ), f"GET /index/{did} expected {expected_status}, got {res.status_code} for user {user_['header']}"
+    if expected_status == 200:
+        data = res.json
+        assert (
+            data["did"] == did
+        ), f"Expected DID {did}, got {data['did']} for user {user_['header']}"
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status, expected_count",
+    [
+        ("public_record", "power_user", 200, 1),
+        ("public_record", "controlled_user", 200, 1),
+        ("public_record", "basic_user", 200, 1),
+        ("public_record", "null_user", 200, 1),
+        ("controlled_record", "power_user", 200, 1),
+        ("controlled_record", "controlled_user", 200, 1),
+        ("controlled_record", "basic_user", 200, 0),
+        ("controlled_record", "null_user", 200, 0),
+        ("private_record", "power_user", 200, 1),
+        ("private_record", "controlled_user", 200, 0),
+        ("private_record", "basic_user", 200, 0),
+        ("private_record", "null_user", 200, 0),
+    ],
+)
+def test_get_drs_objects(
+    client,
+    request,
+    record_fixture,
+    user_fixture,
+    expected_status,
+    expected_count,
+    mock_arborist_requests,
+):
+    """
+    Test /ga4gh/drs/v1/objects for all record and user combinations.
+    """
+    record = request.getfixturevalue(record_fixture)
+    did = record["did"]
+    user_ = request.getfixturevalue(user_fixture)
+
+    ensure_drs(
+        client, did, expected_count, expected_status, mock_arborist_requests, user_
+    )
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status, expected_count",
+    [
+        ("public_record", "power_user", 200, 1),
+        ("public_record", "controlled_user", 200, 1),
+        ("public_record", "basic_user", 200, 1),
+        ("public_record", "null_user", 200, 1),
+        ("controlled_record", "power_user", 200, 1),
+        ("controlled_record", "controlled_user", 200, 1),
+        ("controlled_record", "basic_user", 200, 0),
+        ("controlled_record", "null_user", 200, 0),
+        ("private_record", "power_user", 200, 1),
+        ("private_record", "controlled_user", 200, 0),
+        ("private_record", "basic_user", 200, 0),
+        ("private_record", "null_user", 200, 0),
+    ],
+)
+def test_get_urls(
+    client,
+    request,
+    record_fixture,
+    user_fixture,
+    expected_status,
+    expected_count,
+    mock_arborist_requests,
+):
+    """
+    Test /urls for all record and user combinations.
+    """
+    record = request.getfixturevalue(record_fixture)
+    did = record["did"]
+    user_ = request.getfixturevalue(user_fixture)
+
+    ensure_get_urls(
+        client, did, expected_count, expected_status, mock_arborist_requests, user_
+    )
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status",
+    [
+        ("public_record", "power_user", 200),
+        ("public_record", "controlled_user", 200),
+        ("public_record", "basic_user", 200),
+        ("public_record", "null_user", 200),
+        ("controlled_record", "power_user", 200),
+        ("controlled_record", "controlled_user", 200),
+        ("controlled_record", "basic_user", 401),
+        ("controlled_record", "null_user", 401),
+        ("private_record", "power_user", 200),
+        ("private_record", "controlled_user", 401),
+        ("private_record", "basic_user", 401),
+        ("private_record", "null_user", 401),
+    ],
+)
+def test_get_index_record_by_did(
+    client,
+    request,
+    mock_arborist_requests,
+    record_fixture,
+    user_fixture,
+    expected_status,
+):
+    """
+    Test GET /{did} for each record and user type.
+    """
+    record = request.getfixturevalue(record_fixture)
+    user_ = request.getfixturevalue(user_fixture)
+    did = record["did"]
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    res = client.get(f"/index/{did}", headers=user_["header"])
+    assert (
+        res.status_code == expected_status
+    ), f"GET /index/{did} expected {expected_status}, got {res.status_code} for user {user_['header']}"
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status, expected_count",
+    [
+        ("public_record", "power_user", 200, 1),
+        ("public_record", "controlled_user", 200, 1),
+        ("public_record", "basic_user", 200, 1),
+        ("public_record", "null_user", 200, 1),
+        ("controlled_record", "power_user", 200, 1),
+        ("controlled_record", "controlled_user", 200, 1),
+        ("controlled_record", "basic_user", 401, 0),
+        ("controlled_record", "null_user", 401, 0),
+        ("private_record", "power_user", 200, 1),
+        ("private_record", "controlled_user", 401, 0),
+        ("private_record", "basic_user", 401, 0),
+        ("private_record", "null_user", 401, 0),
+    ],
+)
+def test_get_index_aliases(
+    client,
+    request,
+    record_fixture,
+    user_fixture,
+    expected_status,
+    expected_count,
+    mock_arborist_requests,
+):
+    """
+    Test GET /index/{did}/aliases for all record and user combinations.
+    """
+    record = request.getfixturevalue(record_fixture)
+    did = record["did"]
+    user_ = request.getfixturevalue(user_fixture)
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    url = f"/index/{did}/aliases"
+    res = client.get(url, headers=user_["header"])
+    assert (
+        res.status_code == expected_status
+    ), f"GET {url} expected {expected_status}, got {res.status_code} for user {user_['header']} {res.text}"
+    if expected_status == 200:
+        data = res.json
+        assert isinstance(data, dict), f"Expected dict, got {type(data)}"
+        assert "aliases" in data, f"Expected 'aliases' in response, got {data}"
+        assert (
+            len(data["aliases"]) == expected_count
+        ), f"Expected {expected_count} aliases, got {len(data['aliases'])} for user {user_['header']}"
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status, expected_count",
+    [
+        ("public_record", "power_user", 200, 1),
+        ("public_record", "controlled_user", 200, 1),
+        ("public_record", "basic_user", 200, 1),
+        ("public_record", "null_user", 200, 1),
+        ("controlled_record", "power_user", 200, 1),
+        ("controlled_record", "controlled_user", 200, 1),
+        ("controlled_record", "basic_user", 200, 0),
+        ("controlled_record", "null_user", 200, 0),
+        ("private_record", "power_user", 200, 1),
+        ("private_record", "controlled_user", 200, 0),
+        ("private_record", "basic_user", 200, 0),
+        ("private_record", "null_user", 200, 0),
+    ],
+)
+def test_get_dos_dataobjects(
+    client,
+    request,
+    record_fixture,
+    user_fixture,
+    expected_status,
+    expected_count,
+    mock_arborist_requests,
+):
+    """
+    Test GET /ga4gh/dos/v1/dataobjects for all record and user combinations.
+    """
+    record = request.getfixturevalue(record_fixture)
+    did = record["did"]
+    user_ = request.getfixturevalue(user_fixture)
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    url = f"/ga4gh/dos/v1/dataobjects?ids={did}"
+    res = client.get(url, headers=user_["header"])
+    assert (
+        res.status_code == expected_status
+    ), f"GET {url} expected {expected_status}, got {res.status_code} for user {user_['header']} {res.text}"
+    if expected_status == 200:
+        data = res.json
+        assert isinstance(data, dict), f"Expected dict, got {type(data)}"
+        assert (
+            "data_objects" in data
+        ), f"Expected 'data_objects' in response, got {data}"
+        assert (
+            len(data["data_objects"]) == expected_count
+        ), f"Expected {expected_count} data_objects, got {len(data['data_objects'])} for user {user_['header']}"
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status, expected_count",
+    [
+        ("public_record", "power_user", 200, 1),
+        ("public_record", "controlled_user", 200, 1),
+        ("public_record", "basic_user", 200, 1),
+        ("public_record", "null_user", 200, 1),
+        ("controlled_record", "power_user", 200, 1),
+        ("controlled_record", "controlled_user", 200, 1),
+        ("controlled_record", "basic_user", 200, 0),
+        ("controlled_record", "null_user", 200, 0),
+        ("private_record", "power_user", 200, 1),
+        ("private_record", "controlled_user", 200, 0),
+        ("private_record", "basic_user", 200, 0),
+        ("private_record", "null_user", 200, 0),
+    ],
+)
+def test_get_index_by_project_id_metadata(
+    client,
+    request,
+    record_fixture,
+    user_fixture,
+    expected_status,
+    expected_count,
+    mock_arborist_requests,
+):
+    """
+    Test GET /index/?metadata=project_id:{project_id} for all record and user combinations.
+    """
+    record = request.getfixturevalue(record_fixture)
+    project_id = record["metadata"]["project_id"]
+    user_ = request.getfixturevalue(user_fixture)
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    url = f"/index/?metadata=project_id:{project_id}"
+    res = client.get(url, headers=user_["header"])
+    assert (
+        res.status_code == expected_status
+    ), f"GET {url} expected {expected_status}, got {res.status_code} for user {user_['header']} {res.text}"
+    if expected_status == 200:
+        data = res.json
+        assert isinstance(data, dict), f"Expected dict, got {type(data)}"
+        assert "records" in data, f"Expected 'records' in response, got {data}"
+        assert (
+            len(data["records"]) == expected_count
+        ), f"Expected {expected_count} records, got {len(data['records'])} for user {user_['header']}"
+        if expected_count > 0:
+            assert (
+                data["records"][0]["metadata"]["project_id"] == project_id
+            ), f"Expected project_id {project_id}, got {data['records'][0]['metadata']['project_id']}"
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status, expected_count",
+    [
+        ("public_record", "power_user", 200, 1),
+        ("public_record", "controlled_user", 200, 1),
+        ("public_record", "basic_user", 200, 1),
+        ("public_record", "null_user", 200, 1),
+        ("controlled_record", "power_user", 200, 1),
+        ("controlled_record", "controlled_user", 200, 1),
+        ("controlled_record", "basic_user", 200, 0),
+        ("controlled_record", "null_user", 200, 0),
+        ("private_record", "power_user", 200, 1),
+        ("private_record", "controlled_user", 200, 0),
+        ("private_record", "basic_user", 200, 0),
+        ("private_record", "null_user", 200, 0),
+    ],
+)
+def test_query_urls_q(
+    client,
+    request,
+    record_fixture,
+    user_fixture,
+    expected_status,
+    expected_count,
+    mock_arborist_requests,
+):
+    """
+    Test GET /_query/urls/q for all record and user combinations.
+    """
+
+    # get the record fixture, ensures it was created
+    request.getfixturevalue(record_fixture)
+
+    user_ = request.getfixturevalue(user_fixture)
+    url = f"/_query/urls/q"
+
+    data = _get(client, url, expected_status, user_, mock_arborist_requests)
+
+    if expected_status == 200:
+        assert isinstance(data, list), f"Expected dict, got {type(data)}"
+        assert len(data) == expected_count, f"Expected {expected_count} urls, got {len(data)} for user {user_['header']} {data}"
+        if expected_count > 0:
+            assert "urls" in data[0], f"Expected 'urls' in response, got {data}"
+            assert (
+                len(data[0]["urls"]) == expected_count
+            ), f"Expected {expected_count} urls, got {len(data[0]['urls'])} for user {user_['header']}"
+
+
+@pytest.mark.parametrize(
+    "record_fixture, user_fixture, expected_status, expected_count",
+    [
+        ("public_record", "power_user", 200, 1),
+        ("public_record", "controlled_user", 200, 1),
+        ("public_record", "basic_user", 200, 1),
+        ("public_record", "null_user", 200, 1),
+        ("controlled_record", "power_user", 200, 1),
+        ("controlled_record", "controlled_user", 200, 1),
+        ("controlled_record", "basic_user", 401, 0),
+        ("controlled_record", "null_user", 401, 0),
+        ("private_record", "power_user", 200, 1),
+        ("private_record", "controlled_user", 401, 0),
+        ("private_record", "basic_user", 401, 0),
+        ("private_record", "null_user", 401, 0),
+    ],
+)
+def test_get_index_versions(
+    client,
+    request,
+    record_fixture,
+    user_fixture,
+    expected_status,
+    expected_count,
+    mock_arborist_requests,
+):
+    """
+    Test GET /index/{did}/versions for all record and user combinations.
+    """
+    record = request.getfixturevalue(record_fixture)
+    did = record["did"]
+    user_ = request.getfixturevalue(user_fixture)
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    url = f"/index/{did}/versions"
+    res = client.get(url, headers=user_["header"])
+    assert (
+        res.status_code == expected_status
+    ), f"GET {url} expected {expected_status}, got {res.status_code} for user {user_['header']} {res.text}"
+    if expected_status == 200:
+        data = res.json
+        assert isinstance(data, dict), f"Expected dict, got {type(data)}"
+        # returns a dict indexed by a counter, so we need to check the keys
+        assert (
+            len(data.keys()) == expected_count
+        ), f"Expected {expected_count} versions, got {len(data['versions'])} for user {user_['header']}"
+        assert str(expected_count - 1) in data, f"Expected key '{expected_count - 1}' in response, got {data} for user {user_['header']}"
+

--- a/tests/rbac/test_settings.py
+++ b/tests/rbac/test_settings.py
@@ -1,0 +1,26 @@
+def test_default_settings():
+    """
+    Test that the RBAC in default settings should be False.
+    """
+    from indexd import default_settings
+
+    assert (
+        "config" in default_settings.settings
+    ), "Config should be present in default settings"
+    assert (
+        "RBAC" in default_settings.settings["config"]
+    ), "RBAC setting should be present in default settings"
+    assert (
+        default_settings.settings["config"]["RBAC"] is False
+    ), "RBAC should be disabled by default"
+
+
+def test_rbac_enabled(app_with_rbac):
+    """
+    Test that RBAC is enabled in the app.
+    """
+    assert (
+        "RBAC" in app_with_rbac.config
+    ), "RBAC setting should be present in app_with_rbac.config"
+
+    assert app_with_rbac.config["RBAC"] is True, "RBAC should be enabled in the app"

--- a/tests/rbac/test_writes.py
+++ b/tests/rbac/test_writes.py
@@ -1,0 +1,76 @@
+import pytest
+import copy
+
+
+@pytest.mark.parametrize(
+    "user_fixture, record_fixture, new_hash, new_url, expected_status",
+    [
+        ("power_user", "public_record", {"md5": "e99a18c428cb38d5f260853678922e03"}, "s3://bucket/newkey1", 200),
+        ("controlled_user", "controlled_record", {"md5": "5d41402abc4b2a76b9719d911017c592"}, "s3://bucket/newkey2", 200),
+        ("basic_user", "public_record", {"md5": "098f6bcd4621d373cade4e832627b4f6"}, "s3://bucket/newkey3", 401),
+        ("null_user", "public_record", {"md5": "ad0234829205b9033196ba818f7a872b"}, "s3://bucket/newkey4", 401),
+    ],
+)
+def test_post_index(
+    client,
+    request,
+    user_fixture,
+    record_fixture,
+    new_hash,
+    new_url,
+    expected_status,
+    mock_arborist_requests,
+):
+    """
+    Test POST /index using existing record fixtures as base content, but with modified hashes and urls.
+    """
+    base_record = copy.deepcopy(request.getfixturevalue(record_fixture))
+    user_ = request.getfixturevalue(user_fixture)
+    # the fixtures were updated with the results of a previous POST, so we need to remove these fields
+    del base_record["did"]
+    del base_record["aliases"]
+    del base_record["rev"]
+
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    url = "/index/"
+    res = client.post(url, json=base_record, headers=user_["header"])
+    assert (
+        res.status_code == expected_status
+    ), f"POST {url} expected {expected_status}, got {res.status_code} for user {user_['header']} {res.text}"
+    if expected_status == 200:
+        data = res.json
+        assert "did" in data
+
+
+@pytest.mark.parametrize(
+    "user_fixture, record_fixture, new_alias, expected_status",
+    [
+        ("power_user", "public_record", "new-alias-1", 200),
+        ("controlled_user", "controlled_record", "new-alias-2", 200),
+        # NOTE: Existing code base authorizes basic auth users
+        ("basic_user", "public_record", "new-alias-3", 200),
+        ("null_user", "public_record", "new-alias-4", 401),
+    ],
+)
+def test_post_index_aliases(
+    client,
+    request,
+    user_fixture,
+    record_fixture,
+    new_alias,
+    expected_status,
+    mock_arborist_requests,
+):
+    """
+    Test POST /index/{did}/aliases to add a new alias to an existing record.
+    """
+    base_record = copy.deepcopy(request.getfixturevalue(record_fixture))
+    user_ = request.getfixturevalue(user_fixture)
+    did = base_record["did"]
+    url = f"/index/{did}/aliases"
+    body = {"aliases": [{"value": new_alias}]}
+    mock_arborist_requests(resource_method_to_authorized=user_["permissions"])
+    res = client.post(url, json=body, headers=user_["header"])
+    assert res.status_code == expected_status, f"POST {url} expected {expected_status}, got {res.status_code} for user {user_['header']} {res.text}"
+
+


### PR DESCRIPTION
### New Features

- Introduced Role-Based Access Control (RBAC) to indexd.
  - Added support for enforcing authorization on database operations via Arborist (`adds RBAC to db operations`).
  - Integrated a cached call to Arborist to reduce authorization lookup overhead (`add cached call to Arborist`).
  - Added configuration flag to enable or disable RBAC enforcement (`Adds RBAC config`).

### Breaking Changes

- None. The RBAC feature is gated by a configuration flag and maintains backward compatibility when disabled.

### Bug Fixes

- Improved error messaging for unauthorized access and token validation (`Improve error handling`).

### Improvements

- Added developer documentation for RBAC configuration and usage (`developer documentation`).
- Added test coverage for RBAC behavior (`test RBAC`).

### Dependency updates

- None.

### Deployment changes

- New optional configuration setting: `RBAC`. When set to `True`, RBAC enforcement is active for protected records.
- Arborist must be reachable by the indexd service for RBAC to function properly.
